### PR TITLE
Change unavailable_for_whitelabel redirection logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -227,7 +227,10 @@ class ApplicationController < ActionController::Base
   end
 
   def unavailable_for_whitelabel
-    return redirect_to new_session_url if @whitelabel_mission
+    return unless @whitelabel_mission
+
+    redirect_url = current_user ? projects_url : new_session_url
+    redirect_to redirect_url
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,6 @@ class SessionsController < ApplicationController
       redirect_to_the_build_profile_accounts_page(authentication) && return
       UserMailer.with(whitelabel_mission: @whitelabel_mission).confirm_authentication(authentication).deliver
       flash[:error] = 'Please check your email for confirmation instruction'
-      @path = my_tasks_path
     else
       flash[:error] = 'Failed authentication - Auth hash is missing one or more required values'
       @path = root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -68,7 +68,7 @@ class SessionsController < ApplicationController
       return projects_path if @whitelabel_mission
 
       process_redeem_notice if session[:redeem]
-      process_new_award_notice if current_account.new_award_notice
+      process_new_award_notice if current_account&.new_award_notice
 
       my_tasks_path
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,6 +22,7 @@ class SessionsController < ApplicationController
       redirect_to_the_build_profile_accounts_page(authentication) && return
       UserMailer.with(whitelabel_mission: @whitelabel_mission).confirm_authentication(authentication).deliver
       flash[:error] = 'Please check your email for confirmation instruction'
+      @path = my_tasks_path
     else
       flash[:error] = 'Failed authentication - Auth hash is missing one or more required values'
       @path = root_path
@@ -68,7 +69,7 @@ class SessionsController < ApplicationController
       return projects_path if @whitelabel_mission
 
       process_redeem_notice if session[:redeem]
-      process_new_award_notice if current_account&.new_award_notice
+      process_new_award_notice if current_account.new_award_notice
 
       my_tasks_path
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,6 +9,7 @@ describe ApplicationController do
 
     before_action :redirect_back_to_session, only: %i[index]
     before_action :create_interest_from_session, only: %i[index]
+    before_action :unavailable_for_whitelabel, only: %i[index]
 
     def index
       raise ActiveRecord::RecordNotFound
@@ -201,6 +202,24 @@ describe ApplicationController do
 
         expect(response).to redirect_to root_url
       end
+    end
+  end
+
+  describe '#unavailable_for_whitelabel' do
+    let!(:whitelabel_mission) { create(:mission, whitelabel: true, whitelabel_domain: 'test.host') }
+
+    it 'redirects to new session path for not authorized users' do
+      get :index
+
+      expect(response).to redirect_to new_session_path
+    end
+
+    it 'redirects to projects path for authorized users' do
+      login create(:account)
+
+      get :index
+
+      expect(response).to redirect_to projects_path
     end
   end
 end

--- a/spec/controllers/awards_controller_spec.rb
+++ b/spec/controllers/awards_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe AwardsController, type: :controller do
       create :active_whitelabel_mission
 
       get :index
-      expect(response).to redirect_to(new_session_url)
+      expect(response).to redirect_to(projects_url)
     end
 
     it 'doesnt include whitelabel tasks' do

--- a/spec/controllers/missions_controller_spec.rb
+++ b/spec/controllers/missions_controller_spec.rb
@@ -44,7 +44,7 @@ describe MissionsController do
       create :active_whitelabel_mission
 
       get :index
-      expect(response).to redirect_to(new_session_url)
+      expect(response).to redirect_to(projects_url)
     end
   end
 


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175231932

There are a lot of places where we redirect to `my_tasks_path` (My Tasks) without checking for whitelabel.

But "My tasks" page is disabled for WL:
https://github.com/CoMakery/comakery-server/blob/a92d7fcc60da653b261842d5dd86cf79596c666a/app/controllers/awards_controller.rb#L3

That's why it redirects to the sign-in page.
I've decided that the easiest way to fix that is changing `unavailable_for_whitelabel` redirection logic.
If the user already signed-in let's redirect him to "My projects" page, if not to "Sign in" page.