### PR TITLE
Introduce custom camelize method

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,9 +55,15 @@ module Comakery
     config.generators do |g|
       g.test_framework :rspec
     end
-    
+
+    class CustomCamelize
+      def self.camelize(string)
+        string.sub(/^_/, '').underscore.camelize(:lower)
+      end
+    end
+
     config.react.camelize_props = true
-    config.middleware.use OliveBranch::Middleware, inflection: 'camel'
+    config.middleware.use OliveBranch::Middleware, inflection: 'camel', camelize: CustomCamelize.method(:camelize)
 
     # Use Redis for Cache Store
     redis_provider = ENV.fetch("REDIS_PROVIDER") { "REDIS_URL" }

--- a/public/doc/api/v1/ix._wallets/create_wallet_–_error.html
+++ b/public/doc/api/v1/ix._wallets/create_wallet_–_error.html
@@ -4,7 +4,7 @@
     <title>IX. Wallets API</title>
     <meta charset="utf-8">
     <style>
-      
+
 body {
   font-family: Helvetica,Arial,sans-serif;
   font-size: 13px;
@@ -168,7 +168,7 @@ table th, table td {
             <pre class="request headers">Api-Key: 28ieQrVqi5ZQXd77y+pgiuJGLsFfwkWO</pre>
 
           <h4>Route</h4>
-          <pre class="request route highlight">POST /api/v1/accounts/2118f95e-834e-4347-9e75-0586339115b0/wallets</pre>
+          <pre class="request route highlight">POST /api/v1/accounts/40b019d0-5f4a-4878-ac39-64f86f299750/wallets</pre>
 
 
             <h4>Body</h4>
@@ -176,19 +176,18 @@ table th, table td {
   "body": {
     "data": {
       "wallet": {
-        "blockchain": "bitcoin",
         "address": "3P3QsMVK89JBNqZQv5zMAKG8FK3kJM4rjt"
       }
     },
-    "url": "http://example.org/api/v1/accounts/2118f95e-834e-4347-9e75-0586339115b0/wallets",
+    "url": "http://example.org/api/v1/accounts/40b019d0-5f4a-4878-ac39-64f86f299750/wallets",
     "method": "POST",
-    "nonce": "acefff0b6367d77275c11580589d486a",
-    "timestamp": "1602698164"
+    "nonce": "b9876234ed3affc10fbbd9219a7c03d4",
+    "timestamp": "1602758037"
   },
   "proof": {
     "type": "Ed25519Signature2018",
     "verificationMethod": "O7zTH4xHnD1jRKheBTrpNN24Fg1ddL8DHKi/zgVCVpA=",
-    "signature": "n1HbLrOV8Bh+ez3qV7Fsy0xi9RRVXWNTxO2dkn/UPYfu+UMvUVShwy4wJgAfzHB1r6BJvtquzN1exwJwt+9QCA=="
+    "signature": "5XzUmO5dUq/SJ2KDlA1QXB3VVnz2cpImEtf8KsSgwX9UeJow9EQ8V03/gknSreR87t79C5AVERh1WFMZBl0UBQ=="
   }
 }</pre>
 
@@ -199,8 +198,8 @@ table th, table td {
               <h4>Body</h4>
               <pre class="response body">{
   &quot;errors&quot;: {
-    &quot;Blockchain&quot;: [
-      &quot;has already wallet added&quot;
+    &quot;blockchain&quot;: [
+      &quot;can&#39;t be blank&quot;
     ]
   }
 }</pre>

--- a/spec/acceptance/api/v1/9_wallets_spec.rb
+++ b/spec/acceptance/api/v1/9_wallets_spec.rb
@@ -67,11 +67,7 @@ resource 'IX. Wallets' do
 
     context '400' do
       let!(:id) { account.managed_account_id }
-      let!(:create_params) { { wallet: { blockchain: :bitcoin, address: build(:bitcoin_address_1) } } }
-
-      before do
-        account.wallets.create(_blockchain: :bitcoin, address: build(:bitcoin_address_1))
-      end
+      let!(:create_params) { { wallet: { address: build(:bitcoin_address_1) } } }
 
       example 'CREATE WALLET – ERROR' do
         explanation 'Returns an array of errors'
@@ -79,6 +75,7 @@ resource 'IX. Wallets' do
         request = build(:api_signed_request, create_params, api_v1_account_wallets_path(account_id: account.managed_account_id), 'POST', 'example.org')
         do_request(request)
         expect(status).to eq(400)
+        expect(response_body).to eq '{"errors":{"blockchain":["can\'t be blank"]}}'
       end
     end
   end


### PR DESCRIPTION
Fixes the bug: https://www.pivotaltracker.com/story/show/175231922

If a key begins with an underscore the default `camelize` is uppercase the first letter.
`"_blockchain" => "Blockchain"`

I've introduced `CustomCamelize` which removes underscores in the beginning:
`"_blockchain" => "blockchain"`

It applies to every key of our json response.
