### PR TITLE
Wallets API: Show validation error for unknown blockchain

### DIFF
--- a/app/models/concerns/belongs_to_blockchain.rb
+++ b/app/models/concerns/belongs_to_blockchain.rb
@@ -11,7 +11,7 @@ module BelongsToBlockchain
 
   included do
     enum _blockchain: Blockchain.list, _prefix: :_blockchain
-    validates :_blockchain, presence: true, inclusion: { in: Blockchain.list, message: 'Unknown blockchain value' }
+    validates :_blockchain, presence: true, inclusion: { in: Blockchain.list, message: 'unknown blockchain value' }
 
     def self.blockchain_for(name)
       "Blockchain::#{name.camelize}".constantize.new

--- a/app/models/concerns/belongs_to_blockchain.rb
+++ b/app/models/concerns/belongs_to_blockchain.rb
@@ -10,8 +10,8 @@ module BelongsToBlockchain
   end
 
   included do
-    validates :_blockchain, presence: true
     enum _blockchain: Blockchain.list, _prefix: :_blockchain
+    validates :_blockchain, presence: true, inclusion: { in: Blockchain.list, message: 'Unknown blockchain value' }
 
     def self.blockchain_for(name)
       "Blockchain::#{name.camelize}".constantize.new
@@ -23,6 +23,13 @@ module BelongsToBlockchain
 
     def tokens_on_same_blockchain
       Token.where(_blockchain: _blockchain)
+    end
+
+    # Overwrite the setter to rely on validations instead of [ArgumentError]
+    def _blockchain=(value)
+      super
+    rescue ArgumentError
+      # Skip argument error
     end
   end
 end

--- a/app/models/concerns/belongs_to_blockchain.rb
+++ b/app/models/concerns/belongs_to_blockchain.rb
@@ -11,7 +11,7 @@ module BelongsToBlockchain
 
   included do
     enum _blockchain: Blockchain.list, _prefix: :_blockchain
-    validates :_blockchain, presence: true, inclusion: { in: Blockchain.list.keys.map(&:to_s), message: 'unknown blockchain value' }
+    validates :_blockchain, inclusion: { in: Blockchain.list.keys.map(&:to_s), message: 'unknown blockchain value' }
 
     def self.blockchain_for(name)
       "Blockchain::#{name.camelize}".constantize.new
@@ -29,7 +29,8 @@ module BelongsToBlockchain
     def _blockchain=(value)
       super
     rescue ArgumentError
-      # Skip argument error
+      # Skip argument and reset `_blockchain`
+      self._blockchain = nil
     end
   end
 end

--- a/app/models/concerns/belongs_to_blockchain.rb
+++ b/app/models/concerns/belongs_to_blockchain.rb
@@ -11,7 +11,7 @@ module BelongsToBlockchain
 
   included do
     enum _blockchain: Blockchain.list, _prefix: :_blockchain
-    validates :_blockchain, presence: true, inclusion: { in: Blockchain.list, message: 'unknown blockchain value' }
+    validates :_blockchain, presence: true, inclusion: { in: Blockchain.list.keys.map(&:to_s), message: 'unknown blockchain value' }
 
     def self.blockchain_for(name)
       "Blockchain::#{name.camelize}".constantize.new

--- a/spec/controllers/api/v1/wallets_controller_spec.rb
+++ b/spec/controllers/api/v1/wallets_controller_spec.rb
@@ -72,6 +72,20 @@ RSpec.describe Api::V1::WalletsController, type: :controller do
         expect(response).not_to be_successful
         expect(assigns[:errors]).not_to be_nil
       end
+
+      context 'with unknown blockchain' do
+        let(:create_params) { { wallet: { blockchain: :unknown, address: build(:bitcoin_address_1) } } }
+
+        it 'renders an error' do
+          params = build(:api_signed_request, create_params, api_v1_account_wallets_path(account_id: account.managed_account_id), 'POST')
+          params[:account_id] = account.managed_account_id
+
+          post :create, params: params
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(400)
+          expect(assigns[:errors][:_blockchain]).to eq ['Unknown blockchain value']
+        end
+      end
     end
   end
 

--- a/spec/controllers/api/v1/wallets_controller_spec.rb
+++ b/spec/controllers/api/v1/wallets_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Api::V1::WalletsController, type: :controller do
           post :create, params: params
           expect(response).not_to be_successful
           expect(response).to have_http_status(400)
-          expect(assigns[:errors][:_blockchain]).to eq ['Unknown blockchain value']
+          expect(assigns[:errors][:_blockchain]).to eq ['unknown blockchain value']
         end
       end
     end

--- a/spec/models/concerns/belongs_to_blockchain_spec.rb
+++ b/spec/models/concerns/belongs_to_blockchain_spec.rb
@@ -1,5 +1,6 @@
 shared_examples 'belongs_to_blockchain' do |attrs|
-  it { is_expected.to validate_presence_of(:_blockchain) }
+  it { is_expected.to validate_presence_of(:_blockchain).with_message('unknown blockchain value') }
+  it { is_expected.to validate_inclusion_of(:_blockchain).in_array(Blockchain.list.keys.map(&:to_s)).with_message('unknown blockchain value') }
   it { is_expected.to define_enum_for(:_blockchain).with_values(Blockchain.list).with_prefix(:_blockchain) }
 
   describe '.blockchain_for' do


### PR DESCRIPTION
Fixed the bug: https://www.pivotaltracker.com/story/show/175231909

As it turns out it is a known issue with Rails enum: https://github.com/rails/rails/issues/13971

I've decided to fix it by overwriting setter method and catch the `ArgumentError`
It allowed adding validation and show the validation error.
