### PR TITLE
Wallet: Fix address validation with ore_id

### DIFF
--- a/app/models/concerns/ore_id_features.rb
+++ b/app/models/concerns/ore_id_features.rb
@@ -2,7 +2,7 @@ module OreIdFeatures
   extend ActiveSupport::Concern
 
   included do
-    before_create :pending_for_ore_id
+    before_validation :pending_for_ore_id, on: :create
 
     def ore_id_password_reset_url(redirect_url)
       return unless ore_id?

--- a/db/migrate/20201016083230_change_address_null_for_wallet.rb
+++ b/db/migrate/20201016083230_change_address_null_for_wallet.rb
@@ -1,0 +1,5 @@
+class ChangeAddressNullForWallet < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :wallets, :address, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_160856) do
+ActiveRecord::Schema.define(version: 2020_10_16_083230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -520,7 +520,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_160856) do
 
   create_table "wallets", force: :cascade do |t|
     t.bigint "account_id"
-    t.string "address", null: false
+    t.string "address"
     t.integer "_blockchain", default: 0, null: false
     t.integer "state", default: 0, null: false
     t.integer "source", default: 0, null: false

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -49,11 +49,21 @@ describe Wallet, type: :model do
       specify { expect(subject.state).to eq('ok') }
     end
 
-    it 'works before validation' do
-      wallet = build(:wallet, source: :ore_id)
-      wallet.valid?
+    context 'before validation' do
+      it 'works on create' do
+        wallet = build(:wallet, source: :ore_id)
+        wallet.valid?
 
-      expect(wallet.state).to eq('pending')
+        expect(wallet.state).to eq('pending')
+      end
+
+      it 'ignore on update' do
+        wallet = create(:wallet, source: :ore_id, address: nil)
+        wallet.update(state: :ok)
+        wallet.valid?
+
+        expect(wallet.state).to eq('ok')
+      end
     end
   end
 


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175231932

I've found a bug in tests. Where were false positive because `address` implicitly auto-filled.

- tests fixed
- `address` can be null in the DB
- `state` now set `before_validation` and `on: :create`

P.S. CI fails because of https://github.com/CoMakery/comakery-server/pull/1711
After merge it should pass