### PR TITLE
API docs: Update the main description

### DIFF
--- a/app/views/rspec_api_documentation/html_example.mustache
+++ b/app/views/rspec_api_documentation/html_example.mustache
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{resource_name}} API</title>
+    <meta charset="utf-8">
+    <style>
+      {{{ styles }}}
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>{{resource_name}} API</h1>
+      {{# resource_explanation }}
+
+        <p class="explanation">{{{ resource_explanation }}}</p>
+      {{/ resource_explanation }}
+
+      <div class="article">
+        <h2>{{ description }}</h2>
+        <h3>{{ http_method }} {{ route }}</h3>
+        {{# explanation }}
+          <p class="explanation">
+            {{{ explanation }}}
+          </p>
+        {{/ explanation }}
+
+        {{# has_parameters? }}
+          <h3>Parameters</h3>
+          <table class="parameters table table-striped table-bordered table-condensed">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{# parameters }}
+              <tr>
+                <td{{# required }} class="required"{{/ required }}>
+                  {{# scope }}
+                    <span class="name">{{ scope }}[{{ name }}]</span>
+                  {{/ scope }}
+                  {{^ scope }}
+                    <span class="name">{{ name }}</span>
+                  {{/ scope }}
+                </td>
+                <td>
+                  <span class="description">{{ description }}</span>
+                </td>
+              </tr>
+              {{/ parameters }}
+            </tbody>
+          </table>
+        {{/ has_parameters? }}
+
+        {{# has_response_fields? }}
+          <h3>Response Fields</h3>
+          <table class="response-fields table table-striped table-bordered table-condensed">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{# response_fields }}
+              <tr>
+                <td>
+                  {{# scope }}
+                    <span class="name">{{ scope }}[{{ name }}]</span>
+                  {{/ scope }}
+                  {{^ scope }}
+                    <span class="name">{{ name }}</span>
+                  {{/ scope }}
+                </td>
+                <td>
+                  <span class="description">{{ description }}</span>
+                </td>
+              </tr>
+              {{/ response_fields }}
+            </tbody>
+          </table>
+        {{/ has_response_fields? }}
+
+        {{# requests }}
+          <h3>Request</h3>
+
+          {{# request_headers_text }}
+            <h4>Headers</h4>
+            <pre class="request headers">{{ request_headers_text }}</pre>
+          {{/ request_headers_text }}
+
+          <h4>Route</h4>
+          <pre class="request route highlight">{{ request_method }} {{ request_path }}</pre>
+
+          {{# request_query_parameters_text }}
+            <h4>Query Parameters</h4>
+            <pre class="request query_parameters highlight">{{ request_query_parameters_text }}</pre>
+          {{/ request_query_parameters_text }}
+
+          {{# request_body }}
+            <h4>Body</h4>
+            <pre class="request body">{{{ request_body }}}</pre>
+          {{/ request_body }}
+
+          {{# curl }}
+            <h4>cURL</h4>
+            <pre class="request curl">{{ curl }}</pre>
+          {{/ curl }}
+
+          {{# response_status }}
+            <h3>Response</h3>
+            {{# response_headers_text }}
+              <h4>Headers</h4>
+              <pre class="response headers">{{ response_headers_text }}</pre>
+            {{/ response_headers_text }}
+            <h4>Status</h4>
+            <pre class="response status">{{ response_status }} {{ response_status_text}}</pre>
+            {{# response_body }}
+              <h4>Body</h4>
+              <pre class="response body">{{ response_body }}</pre>
+            {{/ response_body }}
+          {{/ response_status }}
+        {{/ requests }}
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/rspec_api_documentation/html_index.mustache
+++ b/app/views/rspec_api_documentation/html_index.mustache
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ api_name }}</title>
+  <meta charset="utf-8">
+  <style>
+    {{ styles }}
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>{{ api_name }}</h1>
+  {{{ api_explanation }}}
+  {{# sections }}
+  <div class="article">
+    <h2>{{ resource_name }}</h2>
+    {{# resource_explanation }}
+
+      <p class="explanation">{{{ resource_explanation }}}</p>
+    {{/ resource_explanation }}
+
+    <ul>
+      {{# examples }}
+      <li>
+        <a href="/doc/api/v1/{{ dirname }}/{{ filename }}">{{ description }}</a>
+      </li>
+      {{/ examples }}
+    </ul>
+  </div>
+  {{/ sections }}
+</div>
+</body>
+</html>

--- a/config/initializers/rspec_api.rb
+++ b/config/initializers/rspec_api.rb
@@ -53,9 +53,11 @@ RspecApiDocumentation.configure do |config|
   config.api_name = "Comakery Whitelabel API"
 
   # Change the description of the API on index pages
-  config.api_explanation = """
+  config.api_explanation = <<~TEXT
     All of the endpoints below are only accessible via a whitelabel domain, with data scoped to the according instance.
-  """
+    <br><br>
+    <strong>Note:</strong> that there is formatting applied to JSON requests for readability. This makes the example cryptographic signatures for the requests invalid in order to make the examples more readable.
+  TEXT
 
   # Redefine what method the DSL thinks is the client
   # This is useful if you need to `let` your own client, most likely a model.

--- a/config/initializers/rspec_api.rb
+++ b/config/initializers/rspec_api.rb
@@ -23,7 +23,7 @@ RspecApiDocumentation.configure do |config|
   config.format = [:html]
 
   # Location of templates
-  # config.template_path = "inside of the gem"
+  config.template_path = 'app/views/'
 
   # Filter by example document type
   config.filter = :all

--- a/public/doc/api/v1/index.html
+++ b/public/doc/api/v1/index.html
@@ -107,9 +107,10 @@ table th, table td {
 <body>
 <div class="container">
   <h1>Comakery Whitelabel API</h1>
-  
-    All of the endpoints below are only accessible via a whitelabel domain, with data scoped to the according instance.
-  
+  All of the endpoints below are only accessible via a whitelabel domain, with data scoped to the according instance.
+<br><br>
+<strong>Note:</strong> that there is formatting applied to JSON requests for readability. This makes the example cryptographic signatures for the requests invalid in order to make the examples more readable.
+
   <div class="article">
     <h2>I. General</h2>
 
@@ -338,9 +339,6 @@ table th, table td {
       </li>
       <li>
         <a href="ix._wallets/create_wallet.html">CREATE WALLET</a>
-      </li>
-      <li>
-        <a href="ix._wallets/create_wallet_–_error.html">CREATE WALLET – ERROR</a>
       </li>
       <li>
         <a href="ix._wallets/get_wallet.html">GET WALLET</a>

--- a/public/doc/api/v1/index.html
+++ b/public/doc/api/v1/index.html
@@ -341,6 +341,9 @@ table th, table td {
         <a href="/doc/api/v1/ix._wallets/create_wallet.html">CREATE WALLET</a>
       </li>
       <li>
+        <a href="/doc/api/v1/ix._wallets/create_wallet_–_error.html">CREATE WALLET – ERROR</a>
+      </li>
+      <li>
         <a href="/doc/api/v1/ix._wallets/get_wallet.html">GET WALLET</a>
       </li>
       <li>

--- a/public/doc/api/v1/index.html
+++ b/public/doc/api/v1/index.html
@@ -118,25 +118,25 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="i._general/authentication.html">AUTHENTICATION</a>
+        <a href="/doc/api/v1/i._general/authentication.html">AUTHENTICATION</a>
       </li>
       <li>
-        <a href="i._general/authentication_–_incorrect_public_key_header.html">AUTHENTICATION – INCORRECT PUBLIC KEY HEADER</a>
+        <a href="/doc/api/v1/i._general/authentication_–_incorrect_public_key_header.html">AUTHENTICATION – INCORRECT PUBLIC KEY HEADER</a>
       </li>
       <li>
-        <a href="i._general/authentication_–_incorrect_proof.html">AUTHENTICATION – INCORRECT PROOF</a>
+        <a href="/doc/api/v1/i._general/authentication_–_incorrect_proof.html">AUTHENTICATION – INCORRECT PROOF</a>
       </li>
       <li>
-        <a href="i._general/caching.html">CACHING</a>
+        <a href="/doc/api/v1/i._general/caching.html">CACHING</a>
       </li>
       <li>
-        <a href="i._general/throttling.html">THROTTLING</a>
+        <a href="/doc/api/v1/i._general/throttling.html">THROTTLING</a>
       </li>
       <li>
-        <a href="i._general/inflection.html">INFLECTION</a>
+        <a href="/doc/api/v1/i._general/inflection.html">INFLECTION</a>
       </li>
       <li>
-        <a href="i._general/pagination.html">PAGINATION</a>
+        <a href="/doc/api/v1/i._general/pagination.html">PAGINATION</a>
       </li>
     </ul>
   </div>
@@ -147,43 +147,43 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="ii._accounts/get.html">GET</a>
+        <a href="/doc/api/v1/ii._accounts/get.html">GET</a>
       </li>
       <li>
-        <a href="ii._accounts/create.html">CREATE</a>
+        <a href="/doc/api/v1/ii._accounts/create.html">CREATE</a>
       </li>
       <li>
-        <a href="ii._accounts/create_–_error.html">CREATE – ERROR</a>
+        <a href="/doc/api/v1/ii._accounts/create_–_error.html">CREATE – ERROR</a>
       </li>
       <li>
-        <a href="ii._accounts/update.html">UPDATE</a>
+        <a href="/doc/api/v1/ii._accounts/update.html">UPDATE</a>
       </li>
       <li>
-        <a href="ii._accounts/update_–_error.html">UPDATE – ERROR</a>
+        <a href="/doc/api/v1/ii._accounts/update_–_error.html">UPDATE – ERROR</a>
       </li>
       <li>
-        <a href="ii._accounts/interests.html">INTERESTS</a>
+        <a href="/doc/api/v1/ii._accounts/interests.html">INTERESTS</a>
       </li>
       <li>
-        <a href="ii._accounts/create_interest.html">CREATE INTEREST</a>
+        <a href="/doc/api/v1/ii._accounts/create_interest.html">CREATE INTEREST</a>
       </li>
       <li>
-        <a href="ii._accounts/create_interest_–_error.html">CREATE INTEREST – ERROR</a>
+        <a href="/doc/api/v1/ii._accounts/create_interest_–_error.html">CREATE INTEREST – ERROR</a>
       </li>
       <li>
-        <a href="ii._accounts/remove_interest.html">REMOVE INTEREST</a>
+        <a href="/doc/api/v1/ii._accounts/remove_interest.html">REMOVE INTEREST</a>
       </li>
       <li>
-        <a href="ii._accounts/verifications.html">VERIFICATIONS</a>
+        <a href="/doc/api/v1/ii._accounts/verifications.html">VERIFICATIONS</a>
       </li>
       <li>
-        <a href="ii._accounts/create_verification.html">CREATE VERIFICATION</a>
+        <a href="/doc/api/v1/ii._accounts/create_verification.html">CREATE VERIFICATION</a>
       </li>
       <li>
-        <a href="ii._accounts/create_verification_–_error.html">CREATE VERIFICATION – ERROR</a>
+        <a href="/doc/api/v1/ii._accounts/create_verification_–_error.html">CREATE VERIFICATION – ERROR</a>
       </li>
       <li>
-        <a href="ii._accounts/token_balances.html">TOKEN BALANCES</a>
+        <a href="/doc/api/v1/ii._accounts/token_balances.html">TOKEN BALANCES</a>
       </li>
     </ul>
   </div>
@@ -194,10 +194,10 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="iii._projects/index.html">INDEX</a>
+        <a href="/doc/api/v1/iii._projects/index.html">INDEX</a>
       </li>
       <li>
-        <a href="iii._projects/get.html">GET</a>
+        <a href="/doc/api/v1/iii._projects/get.html">GET</a>
       </li>
     </ul>
   </div>
@@ -208,22 +208,22 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="iv._transfers/index.html">INDEX</a>
+        <a href="/doc/api/v1/iv._transfers/index.html">INDEX</a>
       </li>
       <li>
-        <a href="iv._transfers/get.html">GET</a>
+        <a href="/doc/api/v1/iv._transfers/get.html">GET</a>
       </li>
       <li>
-        <a href="iv._transfers/create.html">CREATE</a>
+        <a href="/doc/api/v1/iv._transfers/create.html">CREATE</a>
       </li>
       <li>
-        <a href="iv._transfers/create_–_error.html">CREATE – ERROR</a>
+        <a href="/doc/api/v1/iv._transfers/create_–_error.html">CREATE – ERROR</a>
       </li>
       <li>
-        <a href="iv._transfers/cancel.html">CANCEL</a>
+        <a href="/doc/api/v1/iv._transfers/cancel.html">CANCEL</a>
       </li>
       <li>
-        <a href="iv._transfers/cancel_–_error.html">CANCEL – ERROR</a>
+        <a href="/doc/api/v1/iv._transfers/cancel_–_error.html">CANCEL – ERROR</a>
       </li>
     </ul>
   </div>
@@ -234,19 +234,19 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="v._transfer_rules/index.html">INDEX</a>
+        <a href="/doc/api/v1/v._transfer_rules/index.html">INDEX</a>
       </li>
       <li>
-        <a href="v._transfer_rules/get.html">GET</a>
+        <a href="/doc/api/v1/v._transfer_rules/get.html">GET</a>
       </li>
       <li>
-        <a href="v._transfer_rules/create.html">CREATE</a>
+        <a href="/doc/api/v1/v._transfer_rules/create.html">CREATE</a>
       </li>
       <li>
-        <a href="v._transfer_rules/create_–_error.html">CREATE – ERROR</a>
+        <a href="/doc/api/v1/v._transfer_rules/create_–_error.html">CREATE – ERROR</a>
       </li>
       <li>
-        <a href="v._transfer_rules/delete.html">DELETE</a>
+        <a href="/doc/api/v1/v._transfer_rules/delete.html">DELETE</a>
       </li>
     </ul>
   </div>
@@ -257,19 +257,19 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="vi._account_token_records/index.html">INDEX</a>
+        <a href="/doc/api/v1/vi._account_token_records/index.html">INDEX</a>
       </li>
       <li>
-        <a href="vi._account_token_records/get.html">GET</a>
+        <a href="/doc/api/v1/vi._account_token_records/get.html">GET</a>
       </li>
       <li>
-        <a href="vi._account_token_records/create.html">CREATE</a>
+        <a href="/doc/api/v1/vi._account_token_records/create.html">CREATE</a>
       </li>
       <li>
-        <a href="vi._account_token_records/create_–_error.html">CREATE – ERROR</a>
+        <a href="/doc/api/v1/vi._account_token_records/create_–_error.html">CREATE – ERROR</a>
       </li>
       <li>
-        <a href="vi._account_token_records/delete.html">DELETE</a>
+        <a href="/doc/api/v1/vi._account_token_records/delete.html">DELETE</a>
       </li>
     </ul>
   </div>
@@ -280,28 +280,28 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="vii._blockchain_transactions/generate_transaction.html">GENERATE TRANSACTION</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/generate_transaction.html">GENERATE TRANSACTION</a>
       </li>
       <li>
-        <a href="vii._blockchain_transactions/generate_transaction_–_with_project_transaction_api_key.html">GENERATE TRANSACTION – WITH PROJECT TRANSACTION API KEY</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/generate_transaction_–_with_project_transaction_api_key.html">GENERATE TRANSACTION – WITH PROJECT TRANSACTION API KEY</a>
       </li>
       <li>
-        <a href="vii._blockchain_transactions/generate_transaction_–_transactable_id.html">GENERATE TRANSACTION – TRANSACTABLE ID</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/generate_transaction_–_transactable_id.html">GENERATE TRANSACTION – TRANSACTABLE ID</a>
       </li>
       <li>
-        <a href="vii._blockchain_transactions/generate_transaction_–_transactable_type.html">GENERATE TRANSACTION – TRANSACTABLE TYPE</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/generate_transaction_–_transactable_type.html">GENERATE TRANSACTION – TRANSACTABLE TYPE</a>
       </li>
       <li>
-        <a href="vii._blockchain_transactions/generate_transaction_-_no_transfers.html">GENERATE TRANSACTION - NO TRANSFERS</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/generate_transaction_-_no_transfers.html">GENERATE TRANSACTION - NO TRANSFERS</a>
       </li>
       <li>
-        <a href="vii._blockchain_transactions/submit_transaction.html">SUBMIT TRANSACTION</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/submit_transaction.html">SUBMIT TRANSACTION</a>
       </li>
       <li>
-        <a href="vii._blockchain_transactions/submit_transaction_–_hash_mismatch.html">SUBMIT TRANSACTION – HASH MISMATCH</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/submit_transaction_–_hash_mismatch.html">SUBMIT TRANSACTION – HASH MISMATCH</a>
       </li>
       <li>
-        <a href="vii._blockchain_transactions/cancel_transaction.html">CANCEL TRANSACTION</a>
+        <a href="/doc/api/v1/vii._blockchain_transactions/cancel_transaction.html">CANCEL TRANSACTION</a>
       </li>
     </ul>
   </div>
@@ -312,19 +312,19 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="viii._reg_groups/index.html">INDEX</a>
+        <a href="/doc/api/v1/viii._reg_groups/index.html">INDEX</a>
       </li>
       <li>
-        <a href="viii._reg_groups/get.html">GET</a>
+        <a href="/doc/api/v1/viii._reg_groups/get.html">GET</a>
       </li>
       <li>
-        <a href="viii._reg_groups/create.html">CREATE</a>
+        <a href="/doc/api/v1/viii._reg_groups/create.html">CREATE</a>
       </li>
       <li>
-        <a href="viii._reg_groups/create_–_error.html">CREATE – ERROR</a>
+        <a href="/doc/api/v1/viii._reg_groups/create_–_error.html">CREATE – ERROR</a>
       </li>
       <li>
-        <a href="viii._reg_groups/delete.html">DELETE</a>
+        <a href="/doc/api/v1/viii._reg_groups/delete.html">DELETE</a>
       </li>
     </ul>
   </div>
@@ -335,19 +335,19 @@ table th, table td {
 
     <ul>
       <li>
-        <a href="ix._wallets/index.html">INDEX</a>
+        <a href="/doc/api/v1/ix._wallets/index.html">INDEX</a>
       </li>
       <li>
-        <a href="ix._wallets/create_wallet.html">CREATE WALLET</a>
+        <a href="/doc/api/v1/ix._wallets/create_wallet.html">CREATE WALLET</a>
       </li>
       <li>
-        <a href="ix._wallets/get_wallet.html">GET WALLET</a>
+        <a href="/doc/api/v1/ix._wallets/get_wallet.html">GET WALLET</a>
       </li>
       <li>
-        <a href="ix._wallets/remove_wallet.html">REMOVE WALLET</a>
+        <a href="/doc/api/v1/ix._wallets/remove_wallet.html">REMOVE WALLET</a>
       </li>
       <li>
-        <a href="ix._wallets/get_reset_password_url_(only_ore_id_wallets).html">GET RESET PASSWORD URL (ONLY ORE_ID WALLETS)</a>
+        <a href="/doc/api/v1/ix._wallets/get_reset_password_url_(only_ore_id_wallets).html">GET RESET PASSWORD URL (ONLY ORE_ID WALLETS)</a>
       </li>
     </ul>
   </div>

--- a/public/doc/api/v1/public/index.html
+++ b/public/doc/api/v1/public/index.html
@@ -107,9 +107,10 @@ table th, table td {
 <body>
 <div class="container">
   <h1>Comakery Whitelabel API</h1>
-  
-    All of the endpoints below are only accessible via a whitelabel domain, with data scoped to the according instance.
-  
+  All of the endpoints below are only accessible via a whitelabel domain, with data scoped to the according instance.
+<br><br>
+<strong>Note:</strong> that there is formatting applied to JSON requests for readability. This makes the example cryptographic signatures for the requests invalid in order to make the examples more readable.
+
 </div>
 </body>
 </html>


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175252329 and https://www.pivotaltracker.com/story/show/175279089

### The main description was updates:

Before:
<img width="691" alt="Comakery Whitelabel API 2020-10-16 12-54-39" src="https://user-images.githubusercontent.com/517356/96247628-0a38f680-0fb3-11eb-845b-f51c8d71a8d2.png">

After:
<img width="963" alt="Comakery Whitelabel API 2020-10-16 13-06-28" src="https://user-images.githubusercontent.com/517356/96247641-102ed780-0fb3-11eb-9245-36109a519c7f.png">

### Links to files were fixed.

Before:
`<a href="ii._accounts/get.html">GET</a>`

After:
`<a href="/doc/api/v1/ii._accounts/get.html">GET</a>`
