### PR TITLE
Avoid crash on account page with invalid awards

### DIFF
--- a/app/decorators/award_decorator.rb
+++ b/app/decorators/award_decorator.rb
@@ -4,7 +4,7 @@ class AwardDecorator < Draper::Decorator
   include Rails.application.routes.url_helpers
 
   def ethereum_transaction_address
-    object.ethereum_transaction_address || object.latest_blockchain_transaction&.tx_hash
+    token && (object.ethereum_transaction_address || object.latest_blockchain_transaction&.tx_hash)
   end
 
   def ethereum_transaction_address_short


### PR DESCRIPTION
Make sure that the project token is present before displaying tx address