### PR TITLE
RegGroup: Make blockchain_id readonly

### DIFF
--- a/app/models/reg_group.rb
+++ b/app/models/reg_group.rb
@@ -19,6 +19,7 @@ class RegGroup < ApplicationRecord
   validates :name, :blockchain_id, uniqueness: { scope: :token_id } # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :blockchain_id, inclusion: { in: BLOCKCHAIN_ID_MIN..BLOCKCHAIN_ID_MAX }
 
+  after_initialize :set_blockchain_id
   before_validation :set_name
 
   def self.default_for(token)
@@ -26,6 +27,16 @@ class RegGroup < ApplicationRecord
   end
 
   private
+
+    def set_blockchain_id
+      return if blockchain_id
+      return unless token_id
+
+      last_blockchain_id = RegGroup.where(token_id: token_id).order(blockchain_id: :desc).first&.blockchain_id
+      new_blockchain_id = last_blockchain_id + 1
+
+      self.blockchain_id = new_blockchain_id || 0
+    end
 
     def set_name
       self.name ||= blockchain_id.to_s

--- a/app/models/reg_group.rb
+++ b/app/models/reg_group.rb
@@ -12,6 +12,8 @@ class RegGroup < ApplicationRecord
   BLOCKCHAIN_ID_MAX = 2.pow(256) - 1
   BLOCKCHAIN_ID_MIN = 0
 
+  attr_readonly :blockchain_id
+
   validates_with ComakeryTokenValidator
   validates :name, :blockchain_id, presence: true
   validates :name, :blockchain_id, uniqueness: { scope: :token_id } # rubocop:todo Rails/UniqueValidationWithoutIndex

--- a/app/views/dashboard/transfer_rules/_form_reg_group.html.erb
+++ b/app/views/dashboard/transfer_rules/_form_reg_group.html.erb
@@ -1,6 +1,6 @@
-<%= form_with model: RegGroup.new, url: project_dashboard_reg_groups_path(@project), class: 'reg-groups__form', data: { target: 'reg-group-form.form' } do |f| %>
+<%= form_with model: RegGroup.new(token: @project.token), url: project_dashboard_reg_groups_path(@project), class: 'reg-groups__form', data: { target: 'reg-group-form.form' } do |f| %>
   <%= f.text_field(:name, required: true, placeholder: 'Group Name') %>
-  <%= f.number_field(:blockchain_id, required: true, placeholder: 'ID', min: 0) %>
+  <%= f.number_field(:blockchain_id, required: true, placeholder: 'ID', min: 0, readonly: true) %>
   <%= f.submit('create') %>
   <%= button_tag "cancel", type: 'button', data: {action: 'reg-group-form#hideForm'} %>
 <% end %>

--- a/app/views/dashboard/transfer_rules/_reg_group.html.erb
+++ b/app/views/dashboard/transfer_rules/_reg_group.html.erb
@@ -7,7 +7,7 @@
 
     <%= form_with model: reg_group, url: project_dashboard_reg_group_path(project_id: @project.id, id: reg_group.id), class: 'reg-groups__form reg-groups__form--edit hidden', data: { target: 'reg-group-edit-form.form' } do |f| %>
       <%= f.text_field(:name, required: true, placeholder: 'Group Name') %>
-      <%= f.number_field(:blockchain_id, required: true, placeholder: 'ID', min: 0) %>
+      <%= f.number_field(:blockchain_id, required: true, placeholder: 'ID', min: 0, readonly: true) %>
       <%= f.submit('save', data: {confirm: 'Update group?'}) %>
       <%= button_tag "cancel", type: 'button', data: {action: 'reg-group-edit-form#hideForm'} %>
     <% end %>

--- a/public/doc/api/v1/viii._reg_groups/create.html
+++ b/public/doc/api/v1/viii._reg_groups/create.html
@@ -143,7 +143,7 @@ table th, table td {
                 </td>
               </tr>
               <tr>
-                <td class="required">
+                <td>
                     <span class="name">reg_group[blockchain_id]</span>
                 </td>
                 <td>
@@ -187,26 +187,25 @@ table th, table td {
   "body": {
     "data": {
       "reg_group": {
-        "name": "Test",
-        "blockchain_id": "10"
+        "name": "Test"
       }
     },
     "url": "http://example.org/api/v1/projects/66/reg_groups",
     "method": "POST",
-    "nonce": "cdf1fcf3b70c9421666ea06de0c23a4a",
-    "timestamp": "1602698163"
+    "nonce": "c1bcb25d41e7c4edfc1bde60c0deea84",
+    "timestamp": "1603706460"
   },
   "proof": {
     "type": "Ed25519Signature2018",
     "verificationMethod": "O7zTH4xHnD1jRKheBTrpNN24Fg1ddL8DHKi/zgVCVpA=",
-    "signature": "KQvts0FT35Uzkp5ucy1llldbdIAeiPz5YNU2wmCV9a/OiLAJQRxcyEi18BYN3mbcTw5ivNrQbbTXzLalN6V/Dg=="
+    "signature": "SNAZWXQgK5tBqtsaRixtkxhTMxt24mJZeodqnbXw99UtneqQ+u3/HFaBQKl/amtPrVt0WQ8bMfdPzhAhc5FsCw=="
   }
 }</pre>
 
 
             <h3>Response</h3>
               <h4>Headers</h4>
-              <pre class="response headers">ETag: W/&quot;6b7ac0e9713e44ef0579ae6d2b0d9f6c&quot;</pre>
+              <pre class="response headers">ETag: W/&quot;2b3ab01a39523f65facff6351470b869&quot;</pre>
             <h4>Status</h4>
             <pre class="response status">201 Created</pre>
               <h4>Body</h4>
@@ -214,9 +213,9 @@ table th, table td {
   &quot;id&quot;: 61,
   &quot;name&quot;: &quot;Test&quot;,
   &quot;tokenId&quot;: 105,
-  &quot;blockchainId&quot;: 10,
-  &quot;createdAt&quot;: &quot;2020-10-14T17:56:03.514Z&quot;,
-  &quot;updatedAt&quot;: &quot;2020-10-14T17:56:03.514Z&quot;
+  &quot;blockchainId&quot;: 1060,
+  &quot;createdAt&quot;: &quot;2020-10-26T10:01:00.071Z&quot;,
+  &quot;updatedAt&quot;: &quot;2020-10-26T10:01:00.071Z&quot;
 }</pre>
       </div>
     </div>

--- a/public/doc/api/v1/viii._reg_groups/create_–_error.html
+++ b/public/doc/api/v1/viii._reg_groups/create_–_error.html
@@ -143,7 +143,7 @@ table th, table td {
                 </td>
               </tr>
               <tr>
-                <td class="required">
+                <td>
                     <span class="name">reg_group[blockchain_id]</span>
                 </td>
                 <td>
@@ -192,13 +192,13 @@ table th, table td {
     },
     "url": "http://example.org/api/v1/projects/67/reg_groups",
     "method": "POST",
-    "nonce": "9c378d2d003663534d0845e2bdffc686",
-    "timestamp": "1602698163"
+    "nonce": "32f6571f1e4231b819346b27388bb664",
+    "timestamp": "1603706460"
   },
   "proof": {
     "type": "Ed25519Signature2018",
     "verificationMethod": "O7zTH4xHnD1jRKheBTrpNN24Fg1ddL8DHKi/zgVCVpA=",
-    "signature": "CnWgedMuFzeEz7e7whxGb7f4xyaNDklonXvgqom70GctVQkyCEgv6RdRuJafp9vBafqH7N4YIo66ls9WlZzHAQ=="
+    "signature": "FqawXP8wnPHWRfGIDEXDllng8xFMODtCaPC9yjKYhYGr7Ux6CvhQK8hBpgH75+rAWqAD6Z51gUerGfjpGOBqBQ=="
   }
 }</pre>
 

--- a/spec/acceptance/api/v1/8_reg_groups_spec.rb
+++ b/spec/acceptance/api/v1/8_reg_groups_spec.rb
@@ -73,17 +73,14 @@ resource 'VIII. Reg Groups' do
 
     with_options scope: :reg_group, with_example: true do
       parameter :name, 'reg group name', required: true, type: :string
-      parameter :blockchain_id, 'reg group id on blockchain', required: true, type: :string
+      parameter :blockchain_id, 'reg group id on blockchain', type: :string
     end
 
     context '201' do
       let!(:project_id) { project.id }
 
       let!(:valid_attributes) do
-        {
-          name: 'Test',
-          blockchain_id: '10'
-        }
+        { name: 'Test' }
       end
 
       example 'CREATE' do

--- a/spec/controllers/dashboard/reg_groups_controller_spec.rb
+++ b/spec/controllers/dashboard/reg_groups_controller_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Dashboard::RegGroupsController, type: :controller do
 
     context 'with valid params' do
       it 'updates group record' do
-        put :update, params: { reg_group: valid_attributes.merge(blockchain_id: 100), id: reg_group.id, project_id: project.to_param }
+        put :update, params: { reg_group: valid_attributes.merge(name: 'updated group'), id: reg_group.id, project_id: project.to_param }
         expect(response).to redirect_to(project_dashboard_transfer_rules_path(project))
-        expect(reg_group.reload.blockchain_id).to eq(100)
+        expect(reg_group.reload.name).to eq('updated group')
       end
     end
 


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175413599

RegGroup#blockchain_id became read-only and auto-generated for new RegGroups

<img width="660" alt="WL 2020-10-26 14-02-35" src="https://user-images.githubusercontent.com/517356/97165021-129fe700-1794-11eb-9e29-94683fb8e29d.png">

It works both front-end and back-end parts

Also, I've changed API docs because `blockchain_id` is not required anymore but you still possible to set your own number.