### PR TITLE
TransferRulesSyncJob: Fix sync for last lockup_until is 0

### DIFF
--- a/app/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job.rb
+++ b/app/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job.rb
@@ -16,7 +16,9 @@ module BlockchainJob
         filtered_events.each { |event| process_event(event) }
         filter_unnecessary_rules_updates
 
-        @transfer_rules.each(&:save!)
+        TransferRule.transaction do
+          @transfer_rules.each(&:save!)
+        end
       end
 
       def filtered_events

--- a/app/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job.rb
+++ b/app/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job.rb
@@ -14,6 +14,8 @@ module BlockchainJob
         @client = Comakery::Eth.new(@token.blockchain.explorer_api_host).client
 
         filtered_events.each { |event| process_event(event) }
+        filter_unnecessary_rules_updates
+
         @transfer_rules.each(&:save!)
       end
 
@@ -26,6 +28,19 @@ module BlockchainJob
         ).fetch('result')
       end
 
+      def filter_unnecessary_rules_updates
+        synced_rules = TransferRule.where(token: @token, status: 'synced').to_a
+        @transfer_rules.filter! do |transfer_rule|
+          synced_rule = synced_rules.find do |sr|
+            sr.sending_group_id == transfer_rule.sending_group_id &&
+              sr.receiving_group_id == transfer_rule.receiving_group_id &&
+              sr.lockup_until == transfer_rule.lockup_until
+          end
+
+          synced_rule.nil?
+        end
+      end
+
       def process_event(event_data)
         # removed: true when the log was removed, due to a chain reorganization. false if it's a valid log.
         return if event_data['removed']
@@ -33,8 +48,6 @@ module BlockchainJob
         return unless event_data['transactionHash']
 
         lockup_until = @decoder.decode('uint256', event_data['data'])
-        return if lockup_until.zero?
-
         topics = event_data.fetch('topics')
         blockchain_from_group_id = @decoder.decode('uint256', topics[2])
         blockchain_to_group_id = @decoder.decode('uint256', topics[3])

--- a/spec/features/dashboard/transfer_rules/refresh_transfer_rules_spec.rb
+++ b/spec/features/dashboard/transfer_rules/refresh_transfer_rules_spec.rb
@@ -18,7 +18,7 @@ describe 'refresh_transfer_rules' do
     end
 
     expect(page).to have_content '10 Groups'
-    expect(page).to have_content '35 Rules'
+    expect(page).to have_content '16 Rules'
     expect(page).to have_button 'refresh transfer rules', disabled: true
   end
 end

--- a/spec/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job_spec.rb
+++ b/spec/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BlockchainJob::ComakerySecurityTokenJob::TransferRulesSyncJob, ty
 
     token.reload
     expect(token.reg_groups.count).to eq 10
-    expect(token.transfer_rules.count).to eq 35
+    expect(token.transfer_rules.count).to eq 16
 
     transfer_rule = token.transfer_rules.first
     expect(transfer_rule.token_id).to eq token.id
@@ -42,9 +42,10 @@ RSpec.describe BlockchainJob::ComakerySecurityTokenJob::TransferRulesSyncJob, ty
     expect(permanently_locked_transfer_rules.count).to be_zero
   end
 
-  example 'do not overwrite existing rules and reg groups' do
+  example 'overwrite existing rules and do not overwrite reg groups' do
     reg_group = RegGroup.create!(name: 'Named group', blockchain_id: 1, token: token)
-    transfer_rule = TransferRule.create!(token: token, sending_group: reg_group, receiving_group: reg_group, lockup_until: Time.current, status: 'synced')
+    reg_group_zero = RegGroup.find_by!(token: token, blockchain_id: 0)
+    transfer_rule = TransferRule.create!(token: token, sending_group: reg_group_zero, receiving_group: reg_group, lockup_until: Time.current, status: 'synced')
 
     VCR.use_cassette("infura/#{token._blockchain}/#{token.contract_address}/filtered_logs") do
       described_class.perform_now(token)
@@ -52,7 +53,7 @@ RSpec.describe BlockchainJob::ComakerySecurityTokenJob::TransferRulesSyncJob, ty
 
     token.reload
     expect(token.reg_groups.count).to eq 10
-    expect(token.transfer_rules.count).to eq 35
+    expect(token.transfer_rules.count).to eq 16
 
     reg_group.reload
     expect(reg_group.token_id).to eq token.id
@@ -61,12 +62,44 @@ RSpec.describe BlockchainJob::ComakerySecurityTokenJob::TransferRulesSyncJob, ty
 
     expect(TransferRule.find_by(id: transfer_rule.id)).to be_nil # old rule was deleted
 
-    new_transfer_rule = TransferRule.find_by!(token: token, sending_group: reg_group, receiving_group: reg_group, status: 'synced')
-    expect(new_transfer_rule.lockup_until).to eq Time.zone.parse('2020-04-07')
+    new_transfer_rule = TransferRule.find_by!(token: token, sending_group: reg_group_zero, receiving_group: reg_group, status: 'synced')
+    expect(new_transfer_rule.lockup_until).to eq Time.zone.parse('1970-01-01 00:00:01')
     expect(new_transfer_rule.synced_at).to be > 5.seconds.ago
   end
 
-  example 'with empty filter' do
+  example 'remove existing rule if last lockup_until in blockchain is 0' do
+    allow_any_instance_of(described_class).to receive(:filtered_events).and_return(
+      # 0 => 0 with lockup_until=0
+      [
+        {
+          'address' => '0x1d1592c28fff3d3e71b1d29e31147846026a0a37',
+          'blockHash' => '0x8af77a01acae4e79b51e90d78c7eeac4ee653a0d5991fde71b5d5fa692fe6b68',
+          'blockNumber' => '0x63d00e',
+          'data' => '0x0000000000000000000000000000000000000000000000000000000000000000',
+          'logIndex' => '0x11',
+          'removed' => false,
+          'topics' =>
+          %w[0x5845e315015ee03f0d4ab1d198172b4f733609dc3de8b957ae1d86c874030189
+             0x00000000000000000000000066ebd5cdf54743a6164b0138330f74dce436d842
+             0x0000000000000000000000000000000000000000000000000000000000000000
+             0x0000000000000000000000000000000000000000000000000000000000000000],
+          'transactionHash' => '0xe61ed61e1450c3f4a72039c838dda93b29a7ac367f18240ae7b5d8a886126739',
+          'transactionIndex' => '0x2d'
+        }
+      ]
+    )
+    reg_group_zero = RegGroup.find_by!(token: token, blockchain_id: 0)
+    transfer_rule = TransferRule.create!(token: token, sending_group: reg_group_zero, receiving_group: reg_group_zero, lockup_until: Time.current, status: 'synced')
+    expect(transfer_rule.lockup_until.to_i).to be_positive
+
+    described_class.perform_now(token)
+
+    expect(TransferRule.find_by(id: transfer_rule.id)).to be_nil # old rule was deleted
+    new_transfer_rule = TransferRule.find_by(token: token, sending_group: reg_group_zero, receiving_group: reg_group_zero)
+    expect(new_transfer_rule).to be_nil # no new rule with lockup_until=0
+  end
+
+  example 'with empty results' do
     allow_any_instance_of(described_class).to receive(:filtered_events).and_return([])
 
     described_class.perform_now(token)


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175048822

This PR is a bugfix the case when we have `lockup_until` in blockchain set to 0.
We must delete the TransferRule from DB in this case if we have it.

I also added a filter which does not recreate `TransferRules` in DB if we already have the rule:
https://github.com/CoMakery/comakery-server/blob/92cf655da64568da2bf303e8e500c7c2b48fa9e6/app/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job.rb#L17

And I've added transaction wrapper on save:
https://github.com/CoMakery/comakery-server/blob/92cf655da64568da2bf303e8e500c7c2b48fa9e6/app/jobs/blockchain_job/comakery_security_token_job/transfer_rules_sync_job.rb#L19-L21


