### PR TITLE
TransfersController API: Set description's default to empty string

### DIFF
--- a/app/controllers/api/v1/transfers_controller.rb
+++ b/app/controllers/api/v1/transfers_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::TransfersController < Api::V1::ApiController
 
     award.why = '—'
     award.requirements = '—'
-    award.description ||= '—'
+    award.description ||= ''
 
     if award.save
       @transfer = award

--- a/app/controllers/api/v1/transfers_controller.rb
+++ b/app/controllers/api/v1/transfers_controller.rb
@@ -26,8 +26,8 @@ class Api::V1::TransfersController < Api::V1::ApiController
     award.account = whitelabel_mission.managed_accounts.find_by!(managed_account_id: params.fetch(:body, {}).fetch(:data, {}).fetch(:transfer, {}).fetch(:account_id, {}))
     award.status = :accepted
 
-    award.why = '—'
-    award.requirements = '—'
+    award.why = ''
+    award.requirements = ''
     award.description ||= ''
 
     if award.save

--- a/spec/controllers/api/v1/transfers_controller_spec.rb
+++ b/spec/controllers/api/v1/transfers_controller_spec.rb
@@ -84,6 +84,19 @@ RSpec.describe Api::V1::TransfersController, type: :controller do
         post :create, params: params
         expect(response).to have_http_status(:created)
       end
+
+      it 'fills default values for why, requirements and description' do
+        params = build(:api_signed_request, { transfer: valid_attributes.except(:why, :requirements, :description) }, api_v1_project_transfers_path(project_id: project.id), 'POST')
+        params[:project_id] = project.id
+
+        post :create, params: params
+        expect(response).to have_http_status(:created)
+
+        award = Award.last
+        expect(award.why).to eq '—'
+        expect(award.requirements).to eq '—'
+        expect(award.description).to eq ''
+      end
     end
 
     context 'with invalid params' do

--- a/spec/controllers/api/v1/transfers_controller_spec.rb
+++ b/spec/controllers/api/v1/transfers_controller_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe Api::V1::TransfersController, type: :controller do
         expect(response).to have_http_status(:created)
 
         award = Award.last
-        expect(award.why).to eq '—'
-        expect(award.requirements).to eq '—'
+        expect(award.why).to eq ''
+        expect(award.requirements).to eq ''
         expect(award.description).to eq ''
       end
     end


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175360834

Just changed default:
https://github.com/CoMakery/comakery-server/blob/81a8c17073a9a8dc9b91b83fc290f039f9bcd3ee/app/controllers/api/v1/transfers_controller.rb#L31