### PR TITLE
Accounts: Always show crossed out data if last record not synced

### DIFF
--- a/app/views/dashboard/accounts/_account.html.erb
+++ b/app/views/dashboard/accounts/_account.html.erb
@@ -77,7 +77,7 @@
 	      <label>lockup until</label>
 
 				<div data-target="account-form.outputs">
-					<% if last_record_is_not_synced && synced_record.lockup_until.to_date != last_record.lockup_until.to_date %>
+					<% if last_record_is_not_synced %>
 						<div class="accounts-table_outdated_data">
 							<%= synced_record&.decorate&.lockup_until_pretty %>
 						</div>
@@ -92,7 +92,7 @@
 	      <label>reg group</label>
 
 				<div data-target="account-form.outputs">
-					<% if last_record_is_not_synced && synced_record.reg_group != last_record.reg_group %>
+					<% if last_record_is_not_synced %>
 						<div class="accounts-table_outdated_data">
 							<%= synced_record&.reg_group ? "#{synced_record.reg_group.name} (#{synced_record.reg_group.blockchain_id})" : "–" %>
 						</div>
@@ -107,7 +107,7 @@
 	      <label>frozen</label>
 
 				<div data-target="account-form.outputs">
-					<% if last_record_is_not_synced && synced_record.account_frozen? != last_record.account_frozen? %>
+					<% if last_record_is_not_synced %>
 						<div class="accounts-table_outdated_data">
 							<%= synced_record&.account_frozen? ? "Yes" : "No" %>
 						</div>


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175048825

Just don't compare records.