### PR TITLE
Fix `latest_blockchain_transaction` query

### DIFF
--- a/app/models/concerns/blockchain_transactable.rb
+++ b/app/models/concerns/blockchain_transactable.rb
@@ -4,7 +4,7 @@ module BlockchainTransactable
   included do
     has_many :blockchain_transactions, as: :blockchain_transactable, dependent: :destroy
     # rubocop:todo Rails/InverseOf
-    has_one :latest_blockchain_transaction, -> { order created_at: :desc }, class_name: 'BlockchainTransaction', foreign_key: :blockchain_transactable_id
+    has_one :latest_blockchain_transaction, -> { order created_at: :desc }, class_name: 'BlockchainTransaction', as: :blockchain_transactable, foreign_key: :blockchain_transactable_id
     # rubocop:enable Rails/InverseOf
 
     # Return accepted awards matching at least one of the following conditions:

--- a/spec/models/concerns/blockchain_transactable_spec.rb
+++ b/spec/models/concerns/blockchain_transactable_spec.rb
@@ -1,4 +1,14 @@
 shared_examples 'blockchain_transactable' do
   it { is_expected.to have_many(:blockchain_transactions) }
   it { is_expected.to have_one(:latest_blockchain_transaction) }
+
+  describe 'latest_blockchain_transaction' do
+    it 'returns record which belong to correct type and id' do
+      transaction = create(:blockchain_transaction_transfer_rule)
+      account_token_record = create(:account_token_record, id: transaction.blockchain_transactable.id)
+
+      expect(transaction.blockchain_transactable.latest_blockchain_transaction).to eq(transaction)
+      expect(account_token_record.latest_blockchain_transaction).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Seems like the query is looking up records only by id (foreign_key), not including type.

https://www.pivotaltracker.com/story/show/175765621