### PR TITLE
Fix OreID Unlink

### DIFF
--- a/app/controllers/auth/ore_id_controller.rb
+++ b/app/controllers/auth/ore_id_controller.rb
@@ -9,7 +9,7 @@ class Auth::OreIdController < ApplicationController
 
   # DELETE /auth/ore_id/destroy
   def destroy
-    current_ore_id_account.destroy!
+    current_ore_id_account.unlink
     flash[:notice] = 'ORE ID Unlinked'
     redirect_to wallets_url
   end

--- a/app/models/concerns/belongs_to_ore_id.rb
+++ b/app/models/concerns/belongs_to_ore_id.rb
@@ -10,8 +10,8 @@ module BelongsToOreId
 
     delegate :state, to: :ore_id_account, allow_nil: true
 
-    def cannot_be_destroyed?
-      ore_id?
+    def can_be_destroyed?
+      !ore_id? || ore_id_account.unlinking?
     end
 
     private
@@ -21,7 +21,7 @@ module BelongsToOreId
       end
 
       def abort_destroy_for_ore_id
-        if cannot_be_destroyed?
+        unless can_be_destroyed?
           errors[:base] << 'An ORE ID wallet currently can not be removed'
           throw :abort
         end

--- a/app/models/ore_id_account.rb
+++ b/app/models/ore_id_account.rb
@@ -9,7 +9,7 @@ class OreIdAccount < ApplicationRecord
 
   validates :account_name, uniqueness: { allow_nil: true, allow_blank: false }
 
-  enum state: { pending: 0, pending_manual: 1, unclaimed: 2, ok: 3 }
+  enum state: { pending: 0, pending_manual: 1, unclaimed: 2, ok: 3, unlinking: 4 }
 
   def service
     @service ||= OreIdService.new(self)
@@ -29,6 +29,11 @@ class OreIdAccount < ApplicationRecord
     end
 
     ok!
+  end
+
+  def unlink
+    unlinking!
+    destroy!
   end
 
   private

--- a/spec/controllers/auth/ore_id_controller_spec.rb
+++ b/spec/controllers/auth/ore_id_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Auth::OreIdController, type: :controller do
     end
 
     it 'destroys current_ore_id_account and redirects to wallets url' do
-      expect(current_ore_id_account).to receive(:destroy!)
+      expect(current_ore_id_account).to receive(:unlink)
       delete :destroy
       expect(response).to redirect_to(wallets_url)
     end

--- a/spec/models/ore_id_account_spec.rb
+++ b/spec/models/ore_id_account_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe OreIdAccount, type: :model do
   it { is_expected.to belong_to(:account) }
   it { is_expected.to have_many(:wallets).dependent(:destroy) }
   it { is_expected.to validate_uniqueness_of(:account_name) }
-  it { is_expected.to define_enum_for(:state).with_values({ pending: 0, pending_manual: 1, unclaimed: 2, ok: 3 }) }
+  it { is_expected.to define_enum_for(:state).with_values({ pending: 0, pending_manual: 1, unclaimed: 2, ok: 3, unlinking: 4 }) }
   specify { expect(subject.service).to be_an(OreIdService) }
 
   context 'after_create' do
@@ -65,6 +65,14 @@ RSpec.describe OreIdAccount, type: :model do
 
         expect(subject.account.wallets.last.address).not_to be_nil
       end
+    end
+  end
+
+  describe '#unlink' do
+    specify do
+      expect(subject).to receive(:unlinking!)
+      expect(subject).to receive(:destroy!)
+      subject.unlink
     end
   end
 end

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -29,9 +29,16 @@ describe Wallet, type: :model do
     end
 
     context 'and ore_id_account is pending' do
-      before { expect(subject).to receive(:pending?).and_return(true) }
-
       it { is_expected.not_to validate_presence_of(:address) }
+    end
+
+    context 'and ore_id_account is unlinking' do
+      before { allow_any_instance_of(OreIdAccount).to receive(:unlinking?).and_return(true) }
+
+      it 'allows destroy' do
+        subject.destroy!
+        expect(subject).not_to be_persisted
+      end
     end
   end
 


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/175863184

- Add `unlinking` status to OreIdAccount
- Allow wallet destroy if it belongs to an unlinking ore id account
- Add helper for ore id account unlink