### PR TITLE
Production config: Update SMTP settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,14 +96,14 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :smtp
-  ActionMailer::Base.smtp_settings = {
-      :user_name => ENV['SENDGRID_USERNAME'],
-      :password => ENV['SENDGRID_PASSWORD'],
-      :domain => 'comakery.com',
-      :address => 'smtp.sendgrid.net',
-      :port => 587,
-      :authentication => :plain,
-      :enable_starttls_auto => true
+  config.action_mailer.smtp_settings = {
+    user_name: ENV['SENDGRID_USERNAME'] || ENV['SMTP_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'] || ENV['SMTP_PASSWORD'],
+    domain: ENV['SMTP_DOMAIN'] || ENV['SMTP_ADDRESS'] || 'comakery.com',
+    address: ENV['SMTP_ADDRESS'] || 'smtp.sendgrid.net',
+    port: ENV['SMTP_PORT'] || 587,
+    authentication: ENV['SMTP_PORT'] || :plain,
+    enable_starttls_auto: true
   }
 
   # Should be enabled ONLY on STAGING/DEMO env, since previews expose sensitive data

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,7 +102,7 @@ Rails.application.configure do
     domain: ENV['SMTP_DOMAIN'] || ENV['SMTP_ADDRESS'] || 'comakery.com',
     address: ENV['SMTP_ADDRESS'] || 'smtp.sendgrid.net',
     port: ENV['SMTP_PORT'] || 587,
-    authentication: ENV['SMTP_PORT'] || :plain,
+    authentication: ENV['SMTP_AUTH'] || :plain,
     enable_starttls_auto: true
   }
 


### PR DESCRIPTION
task: https://www.pivotaltracker.com/story/show/175805852

Looks like we can't use SendGrid through Heroku for audit.
I've decided to introduce more general ENV vars to configure any SMTP setting.

I personally love to use https://mailtrap.io/ for stagings servers.
I've configured my personal mailtrap to test it works.

TODO: Change SMTP_* env [here](https://dashboard.heroku.com/apps/comakery-audit/settings) to the company's one.


UPD: I've merged with `new-deploy` branch and uploaded to `comakery-audit` to test and it seems works.
<img width="1183" alt="Mailtrap - Safe Email Testing 2020-12-07 14-05-47" src="https://user-images.githubusercontent.com/517356/101343954-cddc9500-3895-11eb-855e-475c71f6c23e.png">

