### PR TITLE
Wallet API password_reset: Add proof signature into state param

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -45,9 +45,7 @@ class Api::V1::WalletsController < Api::V1::ApiController
 
   # POST /api/v1/accounts/1/wallets/1/password_reset
   def password_reset
-    wallet
-    redirect_url
-
+    @auth_url = wallet.ore_id_account.service.authorization_url(redirect_url, params.dig(:proof, :signature))
     wallet.ore_id_account.schedule_password_update_sync
 
     render 'password_reset.json', status: :ok

--- a/app/views/api/v1/wallets/password_reset.json.jbuilder
+++ b/app/views/api/v1/wallets/password_reset.json.jbuilder
@@ -1,1 +1,1 @@
-json.reset_url @wallet&.ore_id_account&.service&.authorization_url(@redirect_url)
+json.reset_url @auth_url

--- a/public/doc/api/v1/ix._wallets/get_reset_password_url_(only_ore_id_wallets).html
+++ b/public/doc/api/v1/ix._wallets/get_reset_password_url_(only_ore_id_wallets).html
@@ -179,7 +179,7 @@ table th, table td {
             <pre class="request headers">Api-Key: 28ieQrVqi5ZQXd77y+pgiuJGLsFfwkWO</pre>
 
           <h4>Route</h4>
-          <pre class="request route highlight">POST /api/v1/accounts/85212308-2dfe-4689-b02f-24fa8e4f8e02/wallets/24/password_reset</pre>
+          <pre class="request route highlight">POST /api/v1/accounts/def0e4be-c4bf-4277-bc63-3de7eb556b42/wallets/19/password_reset</pre>
 
 
             <h4>Body</h4>
@@ -189,27 +189,27 @@ table th, table td {
     "data": {
       "redirect_url": "localhost"
     },
-    "url": "http://example.org/api/v1/accounts/85212308-2dfe-4689-b02f-24fa8e4f8e02/wallets/24/password_reset",
+    "url": "http://example.org/api/v1/accounts/def0e4be-c4bf-4277-bc63-3de7eb556b42/wallets/19/password_reset",
     "method": "POST",
-    "nonce": "75deef4f624a621e4e2417f12226a87e",
-    "timestamp": "1604580145"
+    "nonce": "3afad04c4ec1aae8a0527495779fb8c8",
+    "timestamp": "1607416766"
   },
   "proof": {
     "type": "Ed25519Signature2018",
     "verificationMethod": "O7zTH4xHnD1jRKheBTrpNN24Fg1ddL8DHKi/zgVCVpA=",
-    "signature": "UdRW9hbazCGikLj3iDQjAA7ZRmXSq0hgFrrkG0qsiTOAAJ8IL2LqvCDczBUURxhCxnQp+0jv4CRI2lpfiN6XDQ=="
+    "signature": "wKD87Dc5L4mR+bhJGCm57qpDBawhkZfmHZyR9ATXIuLxt/M6C5AYpFmFe8rMbEvV83b/opYx28WcCvtHUJLXAg=="
   }
 }</pre>
 
 
             <h3>Response</h3>
               <h4>Headers</h4>
-              <pre class="response headers">ETag: W/&quot;2547daf0c8ef39bbfc13dfc339503c36&quot;</pre>
+              <pre class="response headers">ETag: W/&quot;e80943814849505ece1517b72a5592b2&quot;</pre>
             <h4>Status</h4>
             <pre class="response status">200 OK</pre>
               <h4>Body</h4>
               <pre class="response body">{
-  &quot;resetUrl&quot;: &quot;https://service.oreid.io/auth?app_access_token=dummy_token&amp;background_color=FFFFFF&amp;callback_url=localhost&amp;provider=email&amp;state=&quot;
+  &quot;resetUrl&quot;: &quot;https://service.oreid.io/auth?app_access_token=dummy_token&amp;background_color=FFFFFF&amp;callback_url=localhost&amp;provider=email&amp;state=wKD87Dc5L4mR%2BbhJGCm57qpDBawhkZfmHZyR9ATXIuLxt%2FM6C5AYpFmFe8rMbEvV83b%2FopYx28WcCvtHUJLXAg%3D%3D&quot;
 }</pre>
       </div>
     </div>


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/175805852

For now, the `callback_url` we send to Aikon must be fixed (without dynamics params) and must be exactly the same as URL whitelisted in ORE ID config.
But we can use `state` param for that purposes. So instead of using `recovery_token` param in callback_url we will use `state` param. This state param will be automatically added to calback_url in case of successful password reset.

Example of the `resetUrl ` we returned in the API response: 
```
https://service.oreid.io/auth?app_access_token=dummy_token&background_color=FFFFFF&callback_url=localhost&provider=email&state=wKD87Dc5L4mR%2BbhJGCm57qpDBawhkZfmHZyR9ATXIuLxt%2FM6C5AYpFmFe8rMbEvV83b%2FopYx28WcCvtHUJLXAg%3D%3D
```