### PR TITLE
Improve OreId sign callback error handling

### DIFF
--- a/app/controllers/concerns/ore_id_callbacks.rb
+++ b/app/controllers/concerns/ore_id_callbacks.rb
@@ -39,17 +39,13 @@ module OreIdCallbacks
   def verify_errorless
     if received_error
       flash[:error] = received_error
-      redirect_to wallets_url and return
+      false
     else
       true
     end
   end
 
   def verify_received_account
-    if current_account.id != received_state['account_id']
-      head 401 and return
-    else
-      true
-    end
+    current_account.id == received_state['account_id']
   end
 end

--- a/app/controllers/sign/ore_id_controller.rb
+++ b/app/controllers/sign/ore_id_controller.rb
@@ -16,8 +16,15 @@ class Sign::OreIdController < ApplicationController
 
   # GET /sign/ore_id/receive
   def receive
-    verify_errorless or return
-    verify_received_account or return
+    unless verify_errorless
+      redirect_to wallets_url
+      return
+    end
+
+    unless verify_received_account
+      head 401
+      return
+    end
 
     authorize received_transaction.blockchain_transactable, :pay?
 

--- a/spec/controllers/concerns/ore_id_callbacks_spec.rb
+++ b/spec/controllers/concerns/ore_id_callbacks_spec.rb
@@ -78,9 +78,8 @@ shared_examples 'having ore_id_callbacks' do
         allow_any_instance_of(described_class).to receive(:received_error).and_return('dummy_error')
       end
 
-      it 'adds an error and redirects to wallets_url' do
-        expect(controller).to receive(:redirect_to)
-        controller.verify_errorless
+      it 'adds an error and returns false' do
+        expect(controller.verify_errorless).to be_falsey
         expect(controller.flash[:error]).to eq('dummy_error')
       end
     end
@@ -94,8 +93,7 @@ shared_examples 'having ore_id_callbacks' do
       end
 
       it 'returns 401' do
-        expect(controller).to receive(:head)
-        controller.verify_received_account
+        expect(controller.verify_received_account).to be_falsey
       end
     end
   end

--- a/spec/controllers/sign/ore_id_controller_spec.rb
+++ b/spec/controllers/sign/ore_id_controller_spec.rb
@@ -28,19 +28,44 @@ RSpec.describe Sign::OreIdController, type: :controller, vcr: true do
   describe 'GET /receive' do
     let(:current_ore_id_account) { create(:ore_id) }
 
-    before do
-      expect_any_instance_of(described_class).to receive(:verify_errorless).exactly(2).times.and_return(true)
-      expect_any_instance_of(described_class).to receive(:verify_received_account).and_return(true)
-      allow_any_instance_of(AwardPolicy).to receive(:pay?).and_return(true)
-      allow_any_instance_of(BlockchainJob::BlockchainTransactionSyncJob).to receive(:perform_later)
-      allow_any_instance_of(described_class).to receive(:received_state).and_return({ 'transaction_id' => transaction.id, 'redirect_back_to' => '/dummy_redir_url' })
-      allow_any_instance_of(BlockchainTransaction).to receive(:update).and_return(true)
-      allow_any_instance_of(BlockchainTransaction).to receive(:update_status)
+    context 'with correct callback' do
+      before do
+        expect_any_instance_of(described_class).to receive(:verify_errorless).exactly(2).times.and_return(true)
+        expect_any_instance_of(described_class).to receive(:verify_received_account).and_return(true)
+        allow_any_instance_of(AwardPolicy).to receive(:pay?).and_return(true)
+        allow_any_instance_of(BlockchainJob::BlockchainTransactionSyncJob).to receive(:perform_later)
+        allow_any_instance_of(described_class).to receive(:received_state).and_return({ 'transaction_id' => transaction.id, 'redirect_back_to' => '/dummy_redir_url' })
+        allow_any_instance_of(BlockchainTransaction).to receive(:update).and_return(true)
+        allow_any_instance_of(BlockchainTransaction).to receive(:update_status)
+      end
+
+      it 'updates received transaction, schedules a sync and redirects to redirect_back_to' do
+        get :receive, params: { transaction_id: 'dummy_tx_hash', signed_transaction: Base64.encode64('dummy_raw_tx') }
+        expect(response).to redirect_to('/dummy_redir_url')
+      end
     end
 
-    it 'updates received transaction, schedules a sync and redirects to redirect_back_to' do
-      get :receive, params: { transaction_id: 'dummy_tx_hash', signed_transaction: Base64.encode64('dummy_raw_tx') }
-      expect(response).to redirect_to('/dummy_redir_url')
+    context 'when callback includes error' do
+      before do
+        expect_any_instance_of(described_class).to receive(:verify_errorless).exactly(2).times.and_return(false)
+      end
+
+      it 'redirects to wallets page with the error' do
+        get :receive, params: { transaction_id: 'dummy_tx_hash', signed_transaction: Base64.encode64('dummy_raw_tx') }
+        expect(response).to redirect_to(wallets_url)
+      end
+    end
+
+    context 'when callbacks account doesnt match current one' do
+      before do
+        expect_any_instance_of(described_class).to receive(:verify_errorless).exactly(2).times.and_return(true)
+        expect_any_instance_of(described_class).to receive(:verify_received_account).and_return(false)
+      end
+
+      it 'returns 401' do
+        get :receive, params: { transaction_id: 'dummy_tx_hash', signed_transaction: Base64.encode64('dummy_raw_tx') }
+        expect(response).to have_http_status(401)
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves: https://www.pivotaltracker.com/story/show/175997627

When an error is received during OreId transaction signature, redirect to Wallets page and display the received error instead of raising policy error (due to inability to recover transaction from OreId error state).