### PR TITLE
Fix Synchronisable#sync_allowed? method

### DIFF
--- a/app/models/concerns/synchronisable.rb
+++ b/app/models/concerns/synchronisable.rb
@@ -21,7 +21,7 @@ module Synchronisable
     end
 
     def sync_allowed?
-      Time.current >= next_sync_allowed_after
+      next_sync_allowed_after <= Time.current
     end
 
     def sync_in_progress?


### PR DESCRIPTION
Job Sync still not work. Task: https://www.pivotaltracker.com/story/show/176274061 
I've investigated and it figured out that ruby has quite unexpected (but logically correct) behaviour.

```
[6] pry(main)> Time.current >= Time.current
=> false
[7] pry(main)> Time.current < Time.current
=> true
```

So we still got `sync_allowed?` as false and always rescheduled immediately.

I've changed the order in the condition and it seems work good.