### PR TITLE
Rubocop: Ignore data_migrations files

### DIFF
--- a/config/rubocop/default.yml
+++ b/config/rubocop/default.yml
@@ -10,6 +10,7 @@ AllCops:
     - 'config/**/*'
     - 'db/schema.rb'
     - 'db/migrate/*.rb'
+    - 'db/data_migrations/*.rb'
     - 'node_modules/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'


### PR DESCRIPTION
In #1799 I noticed that we checking data migration files with robocop. I think it's not needed since we ignore regular migrations.