### PR TITLE
PopulateWalletNames data migration: Fix performance issue

### DIFF
--- a/db/data_migrations/20210108101936_populate_wallet_names.rb
+++ b/db/data_migrations/20210108101936_populate_wallet_names.rb
@@ -1,8 +1,9 @@
 class PopulateWalletNames < ActiveRecord::DataMigration
   def up
-    Wallet.find_each do |wallet|
-      wallet.name = wallet.blockchain.name
-      wallet.save
+    Wallet.select('array_agg(id) as ids, _blockchain').group(:_blockchain).each do |blockchain_wallets|
+      blockchain = "Blockchain::#{blockchain_wallets._blockchain.camelize}".constantize.new
+
+      Wallet.where(id: blockchain_wallets.ids).update_all(name: blockchain.name) # rubocop:todo Rails/SkipsModelValidations
     end
   end
 


### PR DESCRIPTION
This PR fixes a deploy to Heroku issue.
I've checked it locally with demo DB and it takes ~ 0.3 sec