### PR TITLE
Provision improvements

### DIFF
--- a/app/models/wallet_provision.rb
+++ b/app/models/wallet_provision.rb
@@ -26,6 +26,8 @@ class WalletProvision < ApplicationRecord
   }
 
   def sync_balance
+    return unless pending?
+
     if wallet.coin_balance&.value&.positive?
       initial_balance_confirmed!
     else
@@ -34,6 +36,8 @@ class WalletProvision < ApplicationRecord
   end
 
   def create_opt_in_tx
+    return unless initial_balance_confirmed?
+
     transaction do
       opt_in = TokenOptIn.find_or_create_by(wallet: wallet, token: token)
       opt_in.pending!
@@ -46,6 +50,8 @@ class WalletProvision < ApplicationRecord
   end
 
   def sync_opt_in_tx
+    return unless opt_in_created?
+
     if wallet.token_opt_ins.all?(&:opted_in?)
       provisioned!
     else

--- a/spec/jobs/ore_id_wallet_opt_in_tx_create_job_spec.rb
+++ b/spec/jobs/ore_id_wallet_opt_in_tx_create_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe OreIdWalletOptInTxCreateJob, type: :job do
   let(:ore_id_account) { create(:ore_id, skip_jobs: true) }
   let(:wallet) { create(:wallet, ore_id_account: ore_id_account, account: ore_id_account.account, _blockchain: :algorand_test, source: :ore_id, address: build(:algorand_address_1)) }
-  let(:wallet_provision) { create(:wallet_provision, wallet: wallet, token: build(:asa_token), state: :pending) }
+  let(:wallet_provision) { create(:wallet_provision, wallet: wallet, token: build(:asa_token), state: :initial_balance_confirmed) }
   subject { wallet_provision }
 
   context 'when sync is allowed' do

--- a/spec/jobs/ore_id_wallet_opt_in_tx_sync_job_spec.rb
+++ b/spec/jobs/ore_id_wallet_opt_in_tx_sync_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe OreIdWalletOptInTxSyncJob, type: :job do
-  subject { create(:wallet_provision) }
+  subject { create(:wallet_provision, state: :opt_in_created) }
 
   context 'when sync is allowed' do
     before { allow_any_instance_of(subject.class).to receive(:sync_allowed?).and_return(true) }

--- a/spec/models/wallet_provision_spec.rb
+++ b/spec/models/wallet_provision_spec.rb
@@ -4,8 +4,9 @@ require 'models/concerns/synchronisable_spec'
 RSpec.describe WalletProvision, type: :model do
   it_behaves_like 'synchronisable'
   before { allow_any_instance_of(described_class).to receive(:sync_allowed?).and_return(true) }
+  let(:provision_state) { :pending }
 
-  subject { create(:wallet_provision, wallet_address: build(:algorand_address_1)) }
+  subject { create(:wallet_provision, wallet_address: build(:algorand_address_1), state: provision_state) }
 
   it { is_expected.to belong_to(:wallet) }
   it { is_expected.to belong_to(:token) }
@@ -46,6 +47,8 @@ RSpec.describe WalletProvision, type: :model do
   end
 
   describe '#sync_balance' do
+    let(:provision_state) { :pending }
+
     before do
       allow(subject).to receive(:wallet).and_return(Wallet.new)
       allow_any_instance_of(Wallet).to receive(:coin_balance).and_return(Balance.new)
@@ -60,6 +63,15 @@ RSpec.describe WalletProvision, type: :model do
 
         expect(subject.state).to eq 'initial_balance_confirmed'
       end
+
+      context 'with non-pending state' do
+        let(:provision_state) { :initial_balance_confirmed }
+
+        specify 'do nothing' do
+          expect_any_instance_of(Wallet).not_to receive(:coin_balance)
+          expect(subject.sync_balance).to be nil
+        end
+      end
     end
 
     context 'when coin balance is not positive' do
@@ -72,6 +84,8 @@ RSpec.describe WalletProvision, type: :model do
   end
 
   describe '#create_opt_in_tx', vcr: true do
+    let(:provision_state) { :initial_balance_confirmed }
+
     context 'when opt_in tx has been created' do
       it 'calls service to sign the transaction' do
         expect_any_instance_of(OreIdService).to receive(:create_tx)
@@ -82,13 +96,33 @@ RSpec.describe WalletProvision, type: :model do
         expect(BlockchainTransactionOptIn.last.blockchain_transactable.wallet).to eq(subject.wallet)
       end
     end
+
+    context 'when state is not initial_balance_confirmed' do
+      let(:provision_state) { :opt_in_created }
+
+      it 'do nothing' do
+        expect(TokenOptIn).not_to receive(:find_or_create_by)
+        expect(subject.create_opt_in_tx).to be nil
+      end
+    end
   end
 
   describe '#sync_opt_in_tx' do
+    let(:provision_state) { :opt_in_created }
+
     context 'when opt_in tx has been confirmed on blockchain' do
       specify do
         expect(subject).to receive(:provisioned!)
         subject.sync_opt_in_tx
+      end
+    end
+
+    context 'when state is not opt_in_created' do
+      let(:provision_state) { :provisioned }
+
+      specify 'do nothing' do
+        expect_any_instance_of(Wallet).not_to receive(:token_opt_ins)
+        expect(subject.sync_opt_in_tx).to be nil
       end
     end
   end

--- a/spec/vcr/WalletProvision/provisioning_step-by-step/1_10_1.yml
+++ b/spec/vcr/WalletProvision/provisioning_step-by-step/1_10_1.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 14 Jan 2021 11:56:41 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d5ac08be24340eb715798ca028d9a81d01610625401; expires=Sat, 13-Feb-21
+        11:56:41 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 07a25a58f00000f21083ae3000000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=MhgUi1a%2F%2FIB6e566FxsPpg3WJWG%2FmWM38giBJLe%2FNe1VIftR9F%2BuDTJmRTEzxmeUtmC%2F1iiYSkkViC5RawxWHvjp2vK9x5L1H1WREuMTqxwKN%2FXE2EBvDehgms3xHUtSSIWZRSxG5%2Bo%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61172cd4ba51f210-ARN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"11710000#JKZTCGNE5GIYI2XVBFEJIVXC5O6TNMUD6REJHN3UXBMKSS3FL5VQ","last-round":11714236,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":11714237,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":4030148334}
+
+        '
+    http_version: null
+  recorded_at: Thu, 14 Jan 2021 11:56:41 GMT
+- request:
+    method: post
+    uri: https://service.oreid.io/api/transaction/sign
+    body:
+      encoding: UTF-8
+      string: '{"account":"ore1raevigpd","user_password":"b1002674f2b8fc0a794ecbf1ea78bfdb79a9bac1f3effdcea7c1c3929aa5647b!","chain_account":"YFGM3UODOZVHSI4HXKPXOKFI6T2YCIK3HKWJYXYFQBONJD4D3HD2DPMYW4","broadcast":true,"chain_network":"algo_test","return_signed_transaction":true,"transaction":"eyJmcm9tIjoiWUZHTTNVT0RPWlZIU0k0SFhLUFhPS0ZJNlQyWUNJSzNIS1dK\nWVhZRlFCT05KRDREM0hEMkRQTVlXNCIsInRvIjoiWUZHTTNVT0RPWlZIU0k0\nSFhLUFhPS0ZJNlQyWUNJSzNIS1dKWVhZRlFCT05KRDREM0hEMkRQTVlXNCIs\nImFtb3VudCI6MCwidHlwZSI6ImF4ZmVyIiwiYXNzZXRJbmRleCI6MTMwNzYz\nNjd9\n"}'
+    headers:
+      Api-Key:
+      - ENV[ORE_ID_API_KEY]
+      Service-Key:
+      - ENV[ORE_ID_API_KEY]
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 14 Jan 2021 11:56:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '108'
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"6c-3FkJhC21EFGiRxCEzvJ47Mbffd4"
+      Via:
+      - 1.1 google
+    body:
+      encoding: UTF-8
+      string: '{"processId":"6150c755a0ab","message":"Problem handling /sign request","error":"Error:
+        api-key isn''t valid"}'
+    http_version: null
+  recorded_at: Thu, 14 Jan 2021 11:56:42 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/176078030

Implemented the comment from tracker:
> We need to add validations of wallet_provision state into the synchronisation methods.
> 
> In case if particular sync is called when the provision in the wrong state we return nil and job is not rescheduled.

Also added an all-in-one test to check provisioning workflow