### PR TITLE
Cover by test the case when nonce was already used

### DIFF
--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     allow(controller).to receive(:authorized).and_return(true)
   end
 
+  describe 'signature check' do
+    render_views
+
+    it 'existing nonce' do
+      params = build(:api_signed_request, '', api_v1_account_path(id: account.managed_account_id), 'GET')
+      params[:id] = account.managed_account_id
+      params[:format] = :json
+
+      nonce = params['body']['nonce']
+      key = "api::v1::nonce_history:#{active_whitelabel_mission.id}:#{nonce}"
+      Rails.cache.write(key, true, expires_in: 1.day)
+
+      get :show, params: params
+      expect(response.status).to eq 401
+      expect(response.body).to eq '{"errors":{"authentication":"Invalid nonce"}}'
+    end
+  end
+
   describe 'GET #show' do
     it 'returns account info by managed_account_id' do
       params = build(:api_signed_request, '', api_v1_account_path(id: account.managed_account_id), 'GET')


### PR DESCRIPTION
The quite important line was not covered:
<img width="593" alt="Code coverage for Comakery-server 2021-01-28 14-03-16" src="https://user-images.githubusercontent.com/517356/106143889-761b2580-6184-11eb-88f3-dfc1188ab104.png">

This PR fix that

![image](https://user-images.githubusercontent.com/517356/106144042-b24e8600-6184-11eb-9a89-935e9ffebf1a.png)
