### PR TITLE
API: raise an error if can not write into cache

### DIFF
--- a/app/controllers/api/v1/concerns/requires_signature.rb
+++ b/app/controllers/api/v1/concerns/requires_signature.rb
@@ -28,7 +28,8 @@ module Api::V1::Concerns::RequiresSignature
       if Rails.cache.exist?(key)
         false
       else
-        Rails.cache.write(key, true, expires_in: 1.day)
+        cache_expiration = Comakery::APISignature::TIMESTAMP_EXPIRATION_SECONDS.seconds
+        CacheExtension.cache_write!(key, true, expires_in: cache_expiration)
       end
     end
   end

--- a/app/controllers/auth/eth_controller.rb
+++ b/app/controllers/auth/eth_controller.rb
@@ -7,7 +7,7 @@ class Auth::EthController < ApplicationController
   # GET /auth/eth/new
   def new
     @nonce = Comakery::Auth::Eth.random_stamp('Authentication Request ')
-    Rails.cache.write("auth_eth::nonce::#{auth_params[:public_address]}", @nonce, expires_in: 1.hour)
+    CacheExtension.cache_write!("auth_eth::nonce::#{auth_params[:public_address]}", @nonce, expires_in: 1.hour)
   end
 
   # POST /auth/eth

--- a/app/lib/cache_extension.rb
+++ b/app/lib/cache_extension.rb
@@ -1,0 +1,14 @@
+module CacheExtension
+  class WriteFailed < StandardError; end
+
+  module_function
+
+  def cache_write!(key, value, options = {})
+    write_result = Rails.cache.write(key, value, **options) # will return nil even it fails, details: https://guides.rubyonrails.org/v6.0/caching_with_rails.html#activesupport-cache-rediscachestore
+
+    # failed to write
+    raise WriteFailed, "Can't write into cache: #{key} = #{value}" unless write_result
+
+    true
+  end
+end

--- a/app/lib/comakery/api_signature.rb
+++ b/app/lib/comakery/api_signature.rb
@@ -88,6 +88,8 @@ module Comakery
     # Allowed ahead of time for timestamp
     TIMESTAMP_AHEAD_SECONDS = 3
 
+    MAX_NONCE_SIZE = 36
+
     # Creates a new request to be verified
     #
     # @param request [Hash] request including body and optioanl proof
@@ -164,7 +166,7 @@ module Comakery
       end
 
       def verify_nonce
-        raise Comakery::APISignatureError, 'Invalid nonce' unless @is_nonce_unique.call(@request.fetch('body', {}).fetch('nonce', ''))
+        raise Comakery::APISignatureError, 'Invalid nonce' unless @is_nonce_unique.call(normalize_nonce(@request.fetch('body', {}).fetch('nonce', '')))
       end
 
       def verify_timestamp
@@ -190,6 +192,10 @@ module Comakery
         )
       rescue Ed25519::VerifyError, ArgumentError
         raise Comakery::APISignatureError, 'Invalid proof signature'
+      end
+
+      def normalize_nonce(nonce)
+        nonce.slice(0, MAX_NONCE_SIZE)
       end
   end
 end

--- a/spec/lib/cache_extension_spec.rb
+++ b/spec/lib/cache_extension_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe CacheExtension do
+  context '.cache_write!' do
+    let(:key) { 'key' }
+    let(:value) { 'val' }
+    let(:options) { { expires_in: 5.seconds } }
+    let(:rails_cache_class) { ActiveSupport::Cache::MemoryStore }
+    subject { described_class.cache_write!(key, value, **options) }
+    before { expect(Rails).to receive(:cache).and_return(rails_cache_class.new) }
+
+    context 'when it wrote successfully' do
+      before { expect_any_instance_of(rails_cache_class).to receive(:write).and_return(true) }
+
+      it { is_expected.to be true }
+
+      context 'and value was nil' do
+        let(:value) { nil }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when cache write returned nil' do
+      before { expect_any_instance_of(rails_cache_class).to receive(:write).and_return(nil) }
+
+      it { expect { subject }.to raise_error CacheExtension::WriteFailed, "Can't write into cache: key = val" }
+    end
+
+    context 'when cache write returned nil' do
+      before { expect_any_instance_of(rails_cache_class).to receive(:write).and_return(nil) }
+
+      it { expect { subject }.to raise_error CacheExtension::WriteFailed, "Can't write into cache: key = val" }
+    end
+  end
+end

--- a/spec/lib/comakery/api_signature_spec.rb
+++ b/spec/lib/comakery/api_signature_spec.rb
@@ -126,6 +126,21 @@ describe Comakery::APISignature do
       end
     end
 
+    context 'with too long nonce' do
+      let(:stubbed_nonce) { 'a' * 50 }
+
+      it 'cut it to MAX_NONCE_SIZE' do
+        is_nonce_unique = lambda do |nonce|
+          expect(nonce.size).to eq Comakery::APISignature::MAX_NONCE_SIZE
+          true
+        end
+
+        expect do
+          described_class.new(valid_signed_request, stubbed_url, stubbed_method, is_nonce_unique).verify(public_key)
+        end.to raise_error(Comakery::APISignatureError, 'Invalid proof signature')
+      end
+    end
+
     context 'with valid request' do
       it 'returns true' do
         expect(described_class.new(valid_signed_request, stubbed_url, stubbed_method).verify(public_key)).to be_truthy


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/176699487

> 1. Raise an error if Rails.cache.write returns false
> 2. Trim provided nonce to 36 characters (UUID length), before processing