### PR TITLE
Add hot wallet deployment setup

### DIFF
--- a/hotwallet/Procfile
+++ b/hotwallet/Procfile
@@ -1,2 +1,3 @@
-web: yarn start
+web: echo "do nothing"
+service: yarn start
 release: yarn install && pm2 reload ecosystem.config.js --env production

--- a/hotwallet/Procfile
+++ b/hotwallet/Procfile
@@ -1,2 +1,2 @@
-worker: yarn start
-release: yarn install
+web: yarn start
+release: yarn install && pm2 reload ecosystem.config.js --env production

--- a/hotwallet/Procfile
+++ b/hotwallet/Procfile
@@ -1,0 +1,2 @@
+worker: yarn start
+release: yarn install

--- a/hotwallet/README.md
+++ b/hotwallet/README.md
@@ -1,8 +1,81 @@
 # Hotwallet
 
-### Deploy to Heroku
+## Deploy to Heroku
+
+### Prepairing
+
+You need prepare some things before deploy:
+1. Comakery's Project id with configured Algorand Security Token as a Project's token.
+2. URL of you Comakery's Whitelable
+3. PROJECT_API_KEY, can be generated in the project's settings on Comakery
+4. PURESTAKE_API, get it from https://developer.purestake.io/home
+5. To setup and grand roles to the hot wallet you should have access to wallet with Contract admin role
+
+### Deploy
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/CoMakery/comakery-server/tree/hotwallet)
+
+On the opened page you have to fill ENV's prepared in previous step and click deploy.
+
+### Preparing for the Hot Wallet
+
+After successful deploy you can see the Hot Wallet address on the Project's transfers page. Now we must configure this wallet to be able to sign and transfer transactions.
+#### Add ALGOs
+
+First of all the how wallet must have enough ALGOs to pay a fee for each transaction. For testnet you can add ALGOs using [Algorand dispenser](https://bank.testnet.algorand.network/).
+#### Opt-in to the algorand security token
+
+To opt in you should go to Heroku, run Heroku console with this command:
+```
+node optIn.js blockchain_network appIndex
+```
+Replace `blockchain_network` with `algorand_test` or `algorand`
+Replace appIndex with actual Algorand Security Token application index
+
+For example this command will opt in to 13997710 Application on Algorand Testnet blockchain:
+```
+node optIn.js algorand_test 13997710
+```
+
+#### Send special transactions to configure the Hot Wallet on the App
+
+To send below transactions you must have wallet with Contract admin roles. We recommend to add this wallet to [Algosigner](https://chrome.google.com/webstore/detail/algosigner/kmmolakhbgdlpkjkcjkebenjheonagdm) chrome extension and send transactions using [this page](https://purestake.github.io/algosigner-dapp-example/tx-test/signTesting.html)
+
+Before send transactions you should copy `firstRound` and `lastRound` from default transaction and replace it in every transaction.
+At the moment it is: `"firstRound":12442137,"lastRound":12443137`
+Also change all `CONTRACT_ADMIN_WALLET_ADDRESS` and `HOT_WALLET_ADDRESS` to actual addresses
+
+#### Send transfer restriction transaction:
+Args:
+  1. freeze: 0 or 1
+  2. maxBalance in the smallest token unit
+  3. lockUntil a UNIX timestamp. 1 is unlocked
+  4. transfer group. 1 is default
+
+```
+{"type":"appl","from":"CONTRACT_ADMIN_WALLET_ADDRESS","fee":1000,"firstRound":12423846,"lastRound":12424846,"genesisID":"testnet-v1.0","genesisHash":"SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=","appIndex":13997710, "appOnComplete":0, "appArgs": ["c2V0QWRkcmVzc1Blcm1pc3Npb25z", [0], [150], [1], [1]],"appAccounts": ["HOT_WALLET_ADDRESS"]}
+```
+
+#### Send grand role transaction:
+Args:
+  1. Role. 1 is for Wallet
+
+```
+{"type":"appl","from":"CONTRACT_ADMIN_WALLET_ADDRESS","fee":1000,"firstRound":12423846,"lastRound":12424846,"genesisID":"testnet-v1.0","genesisHash":"SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=","appIndex":13997710,"appAccounts":["HOT_WALLET_ADDRESS"],"appArgs":["Z3JhbnRSb2xlcw==", [1]],"appOnComplete":0}
+```
+
+#### [Optional] Mint tokens
+
+You can add tokens to the Hot Wallet 2 ways:
+1. Just send from another wallet
+2. To mint tokens using the transaction below
+
+Args:
+  1. Amount of tokens to mint
+
+```
+{"type":"appl","from":"CONTRACT_ADMIN_WALLET_ADDRESS","fee":1000,"firstRound":12423846,"lastRound":12424846,"genesisID":"testnet-v1.0","genesisHash":"SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=","appIndex":13997710, "appOnComplete":0, "appArgs": ["bWludA==", [100]],"appAccounts": ["HOT_WALLET_ADDRESS"]}
+```
 
 ### Setup development enviroment:
 ```shell

--- a/hotwallet/README.md
+++ b/hotwallet/README.md
@@ -2,7 +2,7 @@
 
 ### Deploy to Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/CoMakery/comakery-server/tree/acceptance/hotwallet)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/CoMakery/comakery-server/tree/hotwallet)
 
 ### Setup development enviroment:
 ```shell

--- a/hotwallet/README.md
+++ b/hotwallet/README.md
@@ -1,6 +1,10 @@
 # Hotwallet
 
-### Installation:
+### Deploy to Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/CoMakery/comakery-server/tree/acceptance/hotwallet)
+
+### Setup development enviroment:
 ```shell
 yarn install
 cp .env.example .env

--- a/hotwallet/app.js
+++ b/hotwallet/app.js
@@ -17,7 +17,7 @@ async function initialize() {
   if (!hwUtils.checkAllVariablesAreSet(envs)) { return "Some ENV vars was not set" }
 
   hwUtils.setRedisErrorHandler(redisClient)
-  hwUtils.hotWalletInitialization(envs, redisClient)
+  await hwUtils.hotWalletInitialization(envs, redisClient)
 
   return true
 }

--- a/hotwallet/app.json
+++ b/hotwallet/app.json
@@ -4,9 +4,6 @@
   "repository": "https://github.com/CoMakery/comakery-server/",
   "logo": "https://avatars0.githubusercontent.com/u/17172662",
   "success_url": "/",
-  "scripts": {
-    "postdeploy": "bin/restart"
-  },
   "buildpacks": [
     {
       "url": "heroku/nodejs"

--- a/hotwallet/app.json
+++ b/hotwallet/app.json
@@ -1,0 +1,49 @@
+{
+  "name": "Hot Wallet",
+  "description": "Hot wallet program that will sign and transfer blockchain transactions",
+  "repository": "https://github.com/CoMakery/comakery-server/",
+  "logo": "https://avatars0.githubusercontent.com/u/17172662",
+  "success_url": "/",
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ],
+  "stack": "heroku-18",
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "standard-1x"
+    }
+  },
+  "addons": [
+    {
+      "plan": "heroku-redis:hobby-dev",
+      "as": "REDIS"
+    }
+  ],
+  "env": {
+    "PROJECT_ID": {
+      "description": "The hot wallet will be registered to sign transactions for that CoMakery's project id",
+      "required": true
+    },
+    "PROJECT_API_KEY": {
+      "description": "Api key generated on CoMakery for the PROJECT_ID provided",
+      "required": true
+    },
+    "COMAKERY_SERVER_URL": {
+      "description": "Api key generated on CoMakery for the PROJECT_ID provided",
+      "required": true,
+      "value": "https://comakery.com"
+    },
+    "PURESTAKE_API": {
+      "description": "Api key generated on Purestake to operate with Algorand blockchain",
+      "required": true
+    },
+    "CHECK_FOR_NEW_TRANSACTIONS_DELAY": {
+      "description": "Timeout in second between checking for new transactions to send",
+      "required": true,
+      "value": 30
+    }
+  }
+}

--- a/hotwallet/app.json
+++ b/hotwallet/app.json
@@ -4,6 +4,9 @@
   "repository": "https://github.com/CoMakery/comakery-server/",
   "logo": "https://avatars0.githubusercontent.com/u/17172662",
   "success_url": "/",
+  "scripts": {
+    "postdeploy": "bin/restart"
+  },
   "buildpacks": [
     {
       "url": "heroku/nodejs"
@@ -43,7 +46,7 @@
     "CHECK_FOR_NEW_TRANSACTIONS_DELAY": {
       "description": "Timeout in second between checking for new transactions to send",
       "required": true,
-      "value": 30
+      "value": "30"
     }
   }
 }

--- a/hotwallet/app.json
+++ b/hotwallet/app.json
@@ -11,7 +11,7 @@
   ],
   "stack": "heroku-18",
   "formation": {
-    "web": {
+    "service": {
       "quantity": 1,
       "size": "standard-1x"
     }

--- a/hotwallet/ecosystem.config.js
+++ b/hotwallet/ecosystem.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  apps : [{
+    name: "HotWallet",
+    script: './app.js',
+    instances: 1,
+    env: {
+      NODE_ENV: "development",
+    },
+    env_production: {
+      NODE_ENV: "production",
+    }
+  }],
+
+  deploy : {
+    production : {
+      'post-deploy' : 'yarn install && pm2 reload ecosystem.config.js --env production'
+    }
+  }
+};

--- a/hotwallet/lib/hotwalletUtils.js
+++ b/hotwallet/lib/hotwalletUtils.js
@@ -188,7 +188,7 @@ exports.singAndSendTx = async function singAndSendTx(transactionToSign, envs, re
   }
 }
 
-exports.optInToApp = async function optInToApp(network, envs, redisClient) {
+exports.optInToApp = async function optInToApp(network, appIndex, envs, redisClient) {
   const hget = promisify(redisClient.hget).bind(redisClient)
   let mnemonic
   await hget(exports.keyName(envs.projectId), "mnemonic").then(function (res) { mnemonic = res })
@@ -202,7 +202,7 @@ exports.optInToApp = async function optInToApp(network, envs, redisClient) {
   const txn = {
     from: addr,
     note: 'test optIn',
-    appIndex: 13997710,
+    appIndex: appIndex,
   }
   const action = await algoChain.composeAction(chainjs.ModelsAlgorand.AlgorandChainActionType.AppOptIn, txn)
   transaction.actions = [action]

--- a/hotwallet/optIn.js
+++ b/hotwallet/optIn.js
@@ -1,0 +1,33 @@
+require("dotenv").config()
+const redis = require("redis")
+const hwUtils = require("./lib/hotwalletUtils")
+
+const envs = {
+  projectId: process.env.PROJECT_ID,
+  projectApiKey: process.env.PROJECT_API_KEY,
+  comakeryServerUrl: process.env.COMAKERY_SERVER_URL,
+  purestakeApi: process.env.PURESTAKE_API,
+  redisUrl: process.env.REDIS_URL,
+  checkForNewTransactionsDelay: parseInt(process.env.CHECK_FOR_NEW_TRANSACTIONS_DELAY)
+}
+
+const redisClient = redis.createClient(envs.redisUrl)
+
+async function initialize() {
+  if (!hwUtils.checkAllVariablesAreSet(envs)) { return "Some ENV vars was not set" }
+
+  hwUtils.setRedisErrorHandler(redisClient)
+
+  const args = process.argv.slice(2)
+  const network = args[0]
+  const appIndex = parseInt(args[1])
+  console.log(network, appIndex)
+  await hwUtils.optInToApp(network, appIndex, envs, redisClient)
+
+  return true
+}
+
+(async function () {
+  await initialize()
+  process.exit(0)
+})();

--- a/hotwallet/package.json
+++ b/hotwallet/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "license": "Noncommercial Nonviolent Public License 1.1",
   "scripts": {
+    "start": "pm2-runtime start ecosystem.config.js --env production",
     "test": "jest -i"
   },
   "dependencies": {


### PR DESCRIPTION
Heroku needs a special branch with `app.json` and other files in root directory. It can be done using git subtree.
Comand to push to `hotwallet` branch only the `hotwallet` subfolder:
```
git subtree push --prefix hotwallet origin hotwallet
```

I think the `hotwallet` branch should be protected, it's like `master` branch for CoMakery. And we probably should automatically update it after adding commits to `master`.

[Deploy Instructions](https://github.com/CoMakery/comakery-server/tree/hotwallet)