### PR TITLE
Bugfixes and further OreID UI integrations

### DIFF
--- a/app/controllers/dashboard/accounts_controller.rb
+++ b/app/controllers/dashboard/accounts_controller.rb
@@ -57,7 +57,7 @@ class Dashboard::AccountsController < ApplicationController
     if @project.token.account_token_records.fresh?
       notice = 'Accounts were already synced'
     else
-      AlgorandSecurityToken::AccountTokenRecordsSyncJob.perform_now(@project.token) if @project.token.token_type.is_a?(TokenType::AlgorandSecurityToken)
+      @project.token.token_type.accounts_sync_job&.perform_now(@project.token)
 
       notice = 'Accounts were synced from the blockchain'
     end

--- a/app/controllers/dashboard/accounts_controller.rb
+++ b/app/controllers/dashboard/accounts_controller.rb
@@ -2,7 +2,6 @@ class Dashboard::AccountsController < ApplicationController
   before_action :assign_project
   before_action :normalize_account_token_records_lockup_until_lt, only: [:index]
   before_action :set_accounts, only: [:index]
-  before_action :create_token_records, only: [:index]
   before_action :authorize_project, only: :create
   skip_before_action :require_login, only: %i[index show]
   skip_after_action :verify_policy_scoped, only: %i[index create]
@@ -16,6 +15,8 @@ class Dashboard::AccountsController < ApplicationController
   end
 
   def create
+    authorize @project, :edit_accounts?
+
     account_token_record = @project.token.account_token_records.new(account_token_record_params)
     account_token_record.account_id = params.dig(:account_token_record, :account_id)
     account_token_record.lockup_until = Time.zone.parse(account_token_record_params[:lockup_until])
@@ -50,6 +51,20 @@ class Dashboard::AccountsController < ApplicationController
     end
   end
 
+  def refresh_from_blockchain
+    authorize @project, :accounts?
+
+    if @project.token.account_token_records.fresh?
+      notice = 'Accounts were already synced'
+    else
+      AlgorandSecurityToken::AccountTokenRecordsSyncJob.perform_now(@project.token) if @project.token.token_type.is_a?(TokenType::AlgorandSecurityToken)
+
+      notice = 'Accounts were synced from the blockchain'
+    end
+
+    redirect_to project_dashboard_accounts_path(@project), notice: notice
+  end
+
   private
 
     def normalize_account_token_records_lockup_until_lt
@@ -59,7 +74,13 @@ class Dashboard::AccountsController < ApplicationController
 
     def set_accounts
       @page = (params[:page] || 1).to_i
-      @q = @project.interested.includes(:verifications, :awards, :latest_verification, account_token_records: [:reg_group]).ransack(params[:q])
+      @q = @project.interested.includes(
+        :verifications,
+        :awards,
+        :latest_verification,
+        account_token_records: [:reg_group]
+      ).where.not(account_token_records: { id: nil }).ransack(params[:q])
+
       @accounts_all = @q.result
       @accounts_all.size
       @accounts = @accounts_all.page(@page).per(10)
@@ -79,10 +100,5 @@ class Dashboard::AccountsController < ApplicationController
         :reg_group_id,
         :account_frozen
       )
-    end
-
-    # TODO: Extract creation of account_token_records to model or service
-    def create_token_records
-      @project.interested.each { |a| a.account_token_records.find_or_create_by!(token: @project.token) } if @project.token&.token_type&.operates_with_account_records?
     end
 end

--- a/app/controllers/dashboard/transfer_rules_controller.rb
+++ b/app/controllers/dashboard/transfer_rules_controller.rb
@@ -17,6 +17,7 @@ class Dashboard::TransferRulesController < ApplicationController
   def create
     authorize @project, :edit_transfer_rules?
     transfer_rule = @project.token.transfer_rules.new(transfer_rule_params)
+    transfer_rule.lockup_until = Time.zone.parse(transfer_rule_params[:lockup_until])
 
     if transfer_rule.save
       redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
@@ -30,12 +31,9 @@ class Dashboard::TransferRulesController < ApplicationController
     transfer_rule = @transfer_rule.dup
     transfer_rule.lockup_until = 0
     transfer_rule.status = nil
+    transfer_rule.save!
 
-    if transfer_rule.save
-      redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
-    else
-      redirect_to project_dashboard_transfer_rules_path(@project), flash: { error: @transfer_rule.errors.full_messages.join(', ') }
-    end
+    redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
   end
 
   def freeze

--- a/app/controllers/dashboard/transfer_rules_controller.rb
+++ b/app/controllers/dashboard/transfer_rules_controller.rb
@@ -48,12 +48,7 @@ class Dashboard::TransferRulesController < ApplicationController
     if @project.token.transfer_rules.fresh?
       notice = 'Transfer rules were already synced'
     else
-      if @project.token.token_type.is_a?(TokenType::AlgorandSecurityToken)
-        AlgorandSecurityToken::TransferRulesSyncJob.perform_now(@project.token)
-      else
-        BlockchainJob::ComakerySecurityTokenJob::TransferRulesSyncJob.perform_now(@project.token)
-      end
-
+      @project.token.token_type.transfer_rule_sync_job&.perform_now(@project.token)
       notice = 'Transfer rules were synced from the blockchain'
     end
 

--- a/app/controllers/dashboard/transfer_rules_controller.rb
+++ b/app/controllers/dashboard/transfer_rules_controller.rb
@@ -14,36 +14,33 @@ class Dashboard::TransferRulesController < ApplicationController
     authorize @project, :show_transfer_rules?
   end
 
+  def create
+    authorize @project, :edit_transfer_rules?
+    transfer_rule = @project.token.transfer_rules.new(transfer_rule_params)
+
+    if transfer_rule.save
+      redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
+    else
+      redirect_to project_dashboard_transfer_rules_path(@project), flash: { error: transfer_rule.errors.full_messages.join(', ') }
+    end
+  end
+
   def destroy
     authorize @project, :edit_transfer_rules?
+    transfer_rule = @transfer_rule.dup
+    transfer_rule.lockup_until = 0
+    transfer_rule.status = nil
 
-    if @transfer_rule.destroy
-      redirect_to project_dashboard_transfer_rules_path(@project), notice: 'Transfer rule destroyed'
+    if transfer_rule.save
+      redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
     else
       redirect_to project_dashboard_transfer_rules_path(@project), flash: { error: @transfer_rule.errors.full_messages.join(', ') }
     end
   end
 
-  def pause
+  def freeze
     authorize @project, :freeze_token?
-
-    if @project.token.update(token_frozen: true)
-      BlockchainJob::ComakerySecurityTokenJob::TokenSyncJob.perform_later(@project.token)
-      redirect_to project_dashboard_transfer_rules_path(@project), notice: 'Token tranfers are frozen'
-    else
-      redirect_to project_dashboard_transfer_rules_path(@project), flash: { error: @project.token.errors.full_messages.join(', ') }
-    end
-  end
-
-  def unpause
-    authorize @project, :freeze_token?
-
-    if @project.token.update(token_frozen: false)
-      BlockchainJob::ComakerySecurityTokenJob::TokenSyncJob.perform_later(@project.token)
-      redirect_to project_dashboard_transfer_rules_path(@project), notice: 'Token tranfers are unfrozen'
-    else
-      redirect_to project_dashboard_transfer_rules_path(@project), flash: { error: @project.token.errors.full_messages.join(', ') }
-    end
+    redirect_to sign_ore_id_new_path(token_id: @project.token.id)
   end
 
   def refresh_from_blockchain
@@ -70,5 +67,13 @@ class Dashboard::TransferRulesController < ApplicationController
 
     def set_transfer_rule
       @transfer_rule = @project.token.transfer_rules.find(params[:id])
+    end
+
+    def transfer_rule_params
+      params.fetch(:transfer_rule, {}).permit(
+        :sending_group_id,
+        :receiving_group_id,
+        :lockup_until
+      )
     end
 end

--- a/app/controllers/sign/ore_id_controller.rb
+++ b/app/controllers/sign/ore_id_controller.rb
@@ -1,14 +1,13 @@
 class Sign::OreIdController < ApplicationController
   include OreIdCallbacks
-  skip_after_action :verify_authorized, only: :receive, unless: :verify_errorless
-  skip_after_action :verify_authorized, only: :new, unless: :new_transaction_for_award?
+  skip_after_action :verify_authorized, only: %i[new receive]
 
   # POST /sign/ore_id/new
   def new
     # TODO: Add token admin role to policy token related tx
-    authorize new_transaction.blockchain_transactable, :pay? if new_transaction.is_a?(BlockchainTransactionAward)
+    authorize new_transaction.blockchain_transactable, :pay? if new_transaction_for_award?
 
-    new_transaction.source = current_account.address_for_blockchain(new_transaction.blockchain_transactable._blockchain)
+    new_transaction.source = current_account.address_for_blockchain(new_transaction.blockchain_transactable.token._blockchain)
     new_transaction.save!
 
     redirect_to sign_url(new_transaction)
@@ -29,7 +28,8 @@ class Sign::OreIdController < ApplicationController
       return
     end
 
-    authorize received_transaction.blockchain_transactable, :pay?
+    # TODO: Add token admin role to policy token related tx
+    authorize received_transaction.blockchain_transactable, :pay? if received_transaction_for_award?
 
     if received_transaction.update(tx_hash: params.require(:transaction_id), tx_raw: Base64.decode64(params.require(:signed_transaction)))
       received_transaction.update_status(:pending)
@@ -53,15 +53,19 @@ class Sign::OreIdController < ApplicationController
         BlockchainTransactionAccountTokenRecord.new(
           blockchain_transactable: AccountTokenRecord.find(params.require(:account_token_record_id))
         )
+      elsif params[:transfer_rule_id]
+        BlockchainTransactionTransferRule.new(
+          blockchain_transactable: TransferRule.find(params.require(:transfer_rule_id))
+        )
       elsif params[:token_id]
         t = Token.find(params.require(:token_id))
 
         if t.token_frozen?
-          BlockchainTransactionTokenFreeze.new(
+          BlockchainTransactionTokenUnfreeze.new(
             blockchain_transactable: t
           )
         else
-          BlockchainTransactionTokenUnfreeze.new(
+          BlockchainTransactionTokenFreeze.new(
             blockchain_transactable: t
           )
         end
@@ -70,6 +74,10 @@ class Sign::OreIdController < ApplicationController
 
     def new_transaction_for_award?
       new_transaction.is_a?(BlockchainTransactionAward)
+    end
+
+    def received_transaction_for_award?
+      received_transaction.is_a?(BlockchainTransactionAward)
     end
 
     def received_transaction

--- a/app/controllers/sign/ore_id_controller.rb
+++ b/app/controllers/sign/ore_id_controller.rb
@@ -3,6 +3,7 @@ class Sign::OreIdController < ApplicationController
   skip_after_action :verify_authorized, only: %i[new receive]
 
   # POST /sign/ore_id/new
+  # GET /sign/ore_id/new
   def new
     # TODO: Add token admin role to policy token related tx
     authorize new_transaction.blockchain_transactable, :pay? if new_transaction_for_award?
@@ -14,7 +15,7 @@ class Sign::OreIdController < ApplicationController
   end
 
   # GET /sign/ore_id/receive
-  def receive
+  def receive # rubocop:todo Metrics/CyclomaticComplexity
     fallback_state
 
     unless verify_errorless
@@ -44,7 +45,7 @@ class Sign::OreIdController < ApplicationController
 
   private
 
-    def new_transaction
+    def new_transaction # rubocop:todo Metrics/CyclomaticComplexity
       @new_transaction ||= if params[:transfer_id]
         BlockchainTransactionAward.new(
           blockchain_transactable: policy_scope(Award).find(params.require(:transfer_id))

--- a/app/decorators/account_token_record_decorator.rb
+++ b/app/decorators/account_token_record_decorator.rb
@@ -1,6 +1,46 @@
 class AccountTokenRecordDecorator < Draper::Decorator
   delegate_all
 
+  include Rails.application.routes.url_helpers
+
+  def form_attrs(project)
+    if project.token.blockchain.supported_by_ore_id?
+      form_attrs_ore_id(project)
+    else
+      form_attrs_eth(project)
+    end
+  end
+
+  def form_attrs_ore_id(project)
+    {
+      model: self,
+      url: project_dashboard_accounts_path(project),
+      method: :post,
+      class: 'account-form',
+      data: {
+        controller: 'account-form-controls',
+        target: 'account-form-controls.form'
+      }
+    }
+  end
+
+  def form_attrs_eth(project)
+    {
+      model: self,
+      url: project_dashboard_account_path(project, account),
+      class: 'account-form',
+      method: :get,
+      data: {
+        controller: 'account-form account-form-controls',
+        target: 'account-form.form account-form-controls.form',
+        'account-form-address' => account.address_for_blockchain(project.token._blockchain),
+        'account-form-account-id' => account.id,
+        'account-form-account-token-records-path' => project_dashboard_accounts_path(project_id: project.id),
+        'account-form-transactions-path' => api_v1_project_blockchain_transactions_path(project_id: project.id)
+      }.merge(project.token.decorate.eth_data('account-form'))
+    }
+  end
+
   def lockup_until_pretty
     if lockup_until.to_i > 100.years.from_now.to_i
       '> 100 years'

--- a/app/decorators/transfer_rule_decorator.rb
+++ b/app/decorators/transfer_rule_decorator.rb
@@ -1,6 +1,77 @@
 class TransferRuleDecorator < Draper::Decorator
   delegate_all
 
+  include Rails.application.routes.url_helpers
+
+  def form_attrs(project)
+    if project.token.blockchain.supported_by_ore_id?
+      form_attrs_ore_id(project)
+    else
+      form_attrs_eth(project)
+    end
+  end
+
+  def form_attrs_ore_id(project)
+    {
+      model: TransferRule.new,
+      url: project_dashboard_transfer_rules_path(project),
+      class: 'transfer-rule-form hidden',
+      data: {
+        target: 'transfer-rules.form'
+      }
+    }
+  end
+
+  def form_attrs_eth(project)
+    {
+      model: TransferRule.new,
+      url: project_dashboard_transfer_rules_path(project),
+      class: 'transfer-rule-form hidden',
+      data: {
+        controller: 'transfer-rule-form',
+        target: 'transfer-rule-form.form transfer-rules.form',
+        'transfer-rule-form-transfer-rules-path' => api_v1_project_transfer_rules_path(project_id: project.id),
+        'transfer-rule-form-transactions-path' => api_v1_project_blockchain_transactions_path(project_id: project.id)
+      }.merge(project.token.decorate.eth_data('transfer-rule-form'))
+    }
+  end
+
+  def form_attrs_del(project)
+    if project.token.blockchain.supported_by_ore_id?
+      form_attrs_del_ore_id(project)
+    else
+      form_attrs_del_eth(project)
+    end
+  end
+
+  def form_attrs_del_ore_id(project)
+    {
+      model: self,
+      method: :delete,
+      url: project_dashboard_transfer_rule_path(project, self),
+      class: 'transfer-rule-form'
+    }
+  end
+
+  def form_attrs_del_eth(project)
+    {
+      model: self,
+      method: :delete,
+      url: project_dashboard_transfer_rule_path(project, self),
+      class: 'transfer-rule-form',
+      data: {
+        controller: 'transfer-rule-form',
+        target: 'transfer-rule-form.form',
+        'transfer-rule-form-transfer-rules-path' => api_v1_project_transfer_rules_path(project_id: project.id),
+        'transfer-rule-form-transactions-path' => api_v1_project_blockchain_transactions_path(project_id: project.id)
+      }.merge(
+        eth_data
+      ).merge(
+        project.token.decorate.eth_data('transfer-rule-form')
+      )
+    }
+  end
+
   def eth_data(controller = 'transfer-rule-form')
     {
       "#{controller}-rule-from-group-id" => sending_group.id,

--- a/app/javascript/controllers/account-form-controls_controller.js
+++ b/app/javascript/controllers/account-form-controls_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = [ 'form', 'inputs', 'outputs' ]
+
+  showForm() {
+    document.querySelectorAll('.transfers-table--edit-icon__pencil').forEach(e => {
+      e.classList.add('hidden')
+    })
+
+    this.outputsTargets.forEach((e) => {
+      e.classList.add('hidden')
+    })
+
+    this.inputsTargets.forEach((e) => {
+      e.classList.remove('hidden')
+    })
+
+    this.formTarget.classList.add('account-form--active')
+  }
+
+  hideForm() {
+    document.querySelectorAll('.transfers-table--edit-icon__pencil').forEach(e => {
+      e.classList.remove('hidden')
+    })
+
+    this.inputsTargets.forEach((e) => {
+      e.classList.add('hidden')
+    })
+
+    this.outputsTargets.forEach((e) => {
+      e.classList.remove('hidden')
+    })
+
+    this.formTarget.classList.remove('account-form--active')
+    this.formTarget.reset()
+  }
+}

--- a/app/javascript/controllers/account-form_controller.js
+++ b/app/javascript/controllers/account-form_controller.js
@@ -15,16 +15,12 @@ export default class extends ComakerySecurityTokenController {
       credentials: 'same-origin',
       method     : 'POST',
       body       : JSON.stringify({
-        body: {
-          data: {
-            account_token_record: {
-              'max_balance'   : this.data.get('addressMaxBalance'),
-              'lockup_until'  : this.data.get('addressLockupUntil'),
-              'reg_group_id'  : this.data.get('addressGroupId'),
-              'account_frozen': this.data.get('addressFrozen'),
-              'account_id'    : this.data.get('accountId')
-            }
-          }
+        account_token_record: {
+          'max_balance'   : this.data.get('addressMaxBalance'),
+          'lockup_until'  : this.data.get('addressLockupUntil'),
+          'reg_group_id'  : this.data.get('addressGroupId'),
+          'account_frozen': this.data.get('addressFrozen'),
+          'account_id'    : this.data.get('accountId')
         }
       }),
       headers: {
@@ -70,39 +66,6 @@ export default class extends ComakerySecurityTokenController {
     this.buttonTarget.getElementsByTagName('span')[0].textContent = 'processing'
 
     this.formTarget.requestSubmit()
-  }
-
-  showForm() {
-    document.querySelectorAll('.transfers-table--edit-icon__pencil').forEach(e => {
-      e.classList.add('hidden')
-    })
-
-    this.outputsTargets.forEach((e) => {
-      e.classList.add('hidden')
-    })
-
-    this.inputsTargets.forEach((e) => {
-      e.classList.remove('hidden')
-    })
-
-    this.formTarget.classList.add('account-form--active')
-  }
-
-  hideForm() {
-    document.querySelectorAll('.transfers-table--edit-icon__pencil').forEach(e => {
-      e.classList.remove('hidden')
-    })
-
-    this.inputsTargets.forEach((e) => {
-      e.classList.add('hidden')
-    })
-
-    this.outputsTargets.forEach((e) => {
-      e.classList.remove('hidden')
-    })
-
-    this.formTarget.classList.remove('account-form--active')
-    this.formTarget.reset()
   }
 
   get accountTokenRecordsPath() {

--- a/app/javascript/controllers/transfer-form_controller.js
+++ b/app/javascript/controllers/transfer-form_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from 'stimulus'
 import { Decimal } from 'decimal.js'
 import { Turbo } from '@hotwired/turbo-rails'
+
 export default class extends Controller {
   static targets = [ 'amount', 'quantity', 'total', 'form', 'formChild', 'create' ]
 

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -1220,7 +1220,7 @@ button.reg-groups-create,
 .admins__create input[type="submit"],
 .project-api-key__create a,
 .project-api-key__create button,
-.transfer-rules__refresh_from_blockchain input[type="submit"] {
+input.transfer-rules__refresh_from_blockchain_button {
   margin-bottom: 1.5em;
   border-radius: 6px;
   border: solid 1px #e6e8ed;

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -59,8 +59,8 @@ button.reg-groups-create,
   box-shadow: 0 5px 10px 0 rgba(0, 0, 0, .1);
 
   &:disabled {
-    background-color: #c7c7c7;
-    cursor: not-allowed;
+    background-color: #c7c7c7 !important;
+    cursor: not-allowed !important;
   }
 }
 

--- a/app/jobs/algorand_security_token/account_token_records_sync_job.rb
+++ b/app/jobs/algorand_security_token/account_token_records_sync_job.rb
@@ -1,0 +1,51 @@
+module AlgorandSecurityToken
+  class AccountTokenRecordsSyncJob < ApplicationJob
+    queue_as :default
+
+    attr_reader :token
+
+    def perform(token)
+      @token = token
+
+      opt_ins.each do |opt_in|
+        state = local_state(opt_in.wallet.address)
+
+        AccountTokenRecord.create!(
+          token: token,
+          wallet: opt_in.wallet,
+          account: opt_in.wallet.account,
+          lockup_until: state['lockUntil'],
+          max_balance: state['maxBalance'],
+          reg_group: RegGroup.find_or_create_by!(token: token, blockchain_id: state['transferGroup']),
+          account_frozen: !state['frozen'].zero?,
+          status: :synced,
+          synced_at: Time.current
+        )
+
+        balance = Balance.find_or_initialize_by(
+          token: token,
+          wallet: opt_in.wallet
+        )
+
+        balance.base_unit_value = state['balance']
+        balance.save!
+      end
+    end
+
+    private
+
+      def opt_ins
+        @opt_ins ||= TokenOptIn.opted_in.where(
+          token: token
+        )
+      end
+
+      def app
+        @app ||= Comakery::Algorand.new(token.blockchain, nil, token.contract_address)
+      end
+
+      def local_state(addr)
+        app.account_local_state_decoded(addr)
+      end
+  end
+end

--- a/app/jobs/algorand_security_token/transfer_rules_sync_job.rb
+++ b/app/jobs/algorand_security_token/transfer_rules_sync_job.rb
@@ -1,0 +1,45 @@
+module AlgorandSecurityToken
+  class TransferRulesSyncJob < ApplicationJob
+    queue_as :default
+
+    attr_reader :token
+
+    def perform(token)
+      @token = token
+
+      rules.each do |k, lockup_until|
+        groups = key_to_reg_groups(k)
+
+        TransferRule.create!(
+          token: token,
+          lockup_until: lockup_until,
+          sending_group: groups[0],
+          receiving_group: groups[1],
+          status: :synced,
+          synced_at: Time.current
+        )
+      end
+    end
+
+    private
+
+      def app
+        @app ||= Comakery::Algorand.new(token.blockchain, nil, token.contract_address)
+      end
+
+      def rules
+        @rules ||= app.app_global_state_decoded.select { |k, _v| k.include? 'rule' }
+      end
+
+      def key_to_reg_groups(key)
+        groups = key.split('rule').last
+        from_id = groups.first(8).reverse.unpack1('Q')
+        to_id = groups.last(8).reverse.unpack1('Q')
+
+        [
+          RegGroup.find_or_create_by!(token: token, blockchain_id: from_id),
+          RegGroup.find_or_create_by!(token: token, blockchain_id: to_id)
+        ]
+      end
+  end
+end

--- a/app/jobs/ore_id_wallet_balance_sync_job.rb
+++ b/app/jobs/ore_id_wallet_balance_sync_job.rb
@@ -23,6 +23,14 @@ class OreIdWalletBalanceSyncJob < ApplicationJob
   end
 
   def reschedule(wallet_provision)
-    self.class.set(wait: wallet_provision.next_sync_allowed_after - Time.current).perform_later(wallet_provision)
+    self.class.set(wait: wait_to_perform(wallet_provision)).perform_later(wallet_provision)
+  end
+
+  def wait_to_perform(wallet_provision)
+    if wallet_provision.next_sync_allowed_after < Time.current
+      0
+    else
+      wallet_provision.next_sync_allowed_after - Time.current
+    end
   end
 end

--- a/app/jobs/ore_id_wallet_opt_in_tx_create_job.rb
+++ b/app/jobs/ore_id_wallet_opt_in_tx_create_job.rb
@@ -21,6 +21,14 @@ class OreIdWalletOptInTxCreateJob < ApplicationJob
   end
 
   def reschedule(wallet_provision)
-    self.class.set(wait: wallet_provision.next_sync_allowed_after - Time.current).perform_later(wallet_provision)
+    self.class.set(wait: wait_to_perform(wallet_provision)).perform_later(wallet_provision)
+  end
+
+  def wait_to_perform(wallet_provision)
+    if wallet_provision.next_sync_allowed_after < Time.current
+      0
+    else
+      wallet_provision.next_sync_allowed_after - Time.current
+    end
   end
 end

--- a/app/jobs/ore_id_wallet_opt_in_tx_sync_job.rb
+++ b/app/jobs/ore_id_wallet_opt_in_tx_sync_job.rb
@@ -21,6 +21,14 @@ class OreIdWalletOptInTxSyncJob < ApplicationJob
   end
 
   def reschedule(wallet_provision)
-    self.class.set(wait: wallet_provision.next_sync_allowed_after - Time.current).perform_later(wallet_provision)
+    self.class.set(wait: wait_to_perform(wallet_provision)).perform_later(wallet_provision)
+  end
+
+  def wait_to_perform(wallet_provision)
+    if wallet_provision.next_sync_allowed_after < Time.current
+      0
+    else
+      wallet_provision.next_sync_allowed_after - Time.current
+    end
   end
 end

--- a/app/lib/comakery/algorand.rb
+++ b/app/lib/comakery/algorand.rb
@@ -1,8 +1,8 @@
 class Comakery::Algorand
   def initialize(blockchain, asset_id = nil, app_id = nil)
     @blockchain = blockchain
-    @asset_id = asset_id
-    @app_id = app_id
+    @asset_id = asset_id.to_i
+    @app_id = app_id.to_i
   end
 
   def symbol

--- a/app/lib/comakery/algorand/tx.rb
+++ b/app/lib/comakery/algorand/tx.rb
@@ -67,7 +67,7 @@ class Comakery::Algorand::Tx
   end
 
   def valid_amount?
-    blockchain_transaction.amount == amount
+    blockchain_transaction.amount.to_i == amount
   end
 
   def valid_round?

--- a/app/lib/comakery/algorand/tx/app.rb
+++ b/app/lib/comakery/algorand/tx/app.rb
@@ -65,7 +65,7 @@ class Comakery::Algorand::Tx::App < Comakery::Algorand::Tx
       when String
         Base64.encode64(a).strip
       when Integer
-        Base64.encode64(encode_int_as_bytes(a).pack('c*')).strip
+        Base64.encode64(encode_int_as_bytes(a).pack('C*')).strip
       else
         raise "Unsupported app argument: #{a}:#{a.class}"
       end
@@ -73,7 +73,7 @@ class Comakery::Algorand::Tx::App < Comakery::Algorand::Tx
   end
 
   def encode_int_as_bytes(int)
-    int.zero? ? [0] : [int].pack('N').bytes.drop_while(&:zero?)
+    int.zero? ? [0] : [int].pack('Q').bytes.reverse.drop_while(&:zero?)
   end
 
   def app_transaction_on_completion

--- a/app/lib/comakery/algorand/tx/app/security_token/set_address_permissions.rb
+++ b/app/lib/comakery/algorand/tx/app/security_token/set_address_permissions.rb
@@ -11,7 +11,7 @@ class Comakery::Algorand::Tx::App::SecurityToken::SetAddressPermissions < Comake
 
   def app_accounts
     [
-      blockchain_transaction.blockchain_transactable.account.address_for_blockchain(blockchain_transaction.token._blockchain)
+      blockchain_transaction.destination
     ]
   end
 end

--- a/app/models/account_token_record.rb
+++ b/app/models/account_token_record.rb
@@ -37,7 +37,7 @@ class AccountTokenRecord < ApplicationRecord
   private
 
     def set_defaults
-      self.lockup_until ||= Time.current
+      self.lockup_until ||= 0
       self.reg_group ||= RegGroup.default_for(token)
     end
 

--- a/app/models/account_token_record.rb
+++ b/app/models/account_token_record.rb
@@ -1,5 +1,6 @@
 class AccountTokenRecord < ApplicationRecord
   include BlockchainTransactable
+  include Refreshable
 
   belongs_to :account
   belongs_to :token

--- a/app/models/blockchain_transaction_account_token_record.rb
+++ b/app/models/blockchain_transaction_account_token_record.rb
@@ -20,6 +20,11 @@ class BlockchainTransactionAccountTokenRecord < BlockchainTransaction
     Comakery::Algorand::Tx::App::SecurityToken::SetAddressPermissions.new(self)
   end
 
+  def populate_data
+    super
+    self.destination ||= blockchain_transactable.wallet.address
+  end
+
   private
 
     def tx

--- a/app/models/concerns/refreshable.rb
+++ b/app/models/concerns/refreshable.rb
@@ -1,0 +1,12 @@
+module Refreshable
+  extend ActiveSupport::Concern
+
+  # Requires `:synced` scope and `:synced_at` timestamp
+
+  included do
+    def self.fresh?
+      last_sync = synced.order(synced_at: :desc).first&.synced_at
+      last_sync && last_sync > 10.minutes.ago
+    end
+  end
+end

--- a/app/models/reg_group.rb
+++ b/app/models/reg_group.rb
@@ -23,7 +23,7 @@ class RegGroup < ApplicationRecord
   before_validation :set_name
 
   def self.default_for(token)
-    RegGroup.find_or_create_by!(token_id: token.id, blockchain_id: 0)
+    RegGroup.find_or_create_by!(token_id: token.id, blockchain_id: token.token_type.default_reg_group)
   end
 
   private

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -111,16 +111,6 @@ class Token < ApplicationRecord
     RegGroup.default_for(self)
   end
 
-  def transfer_rules_fresh?
-    last_sync = transfer_rules.synced.order(synced_at: :desc).first&.synced_at
-    last_sync.nil? || last_sync < 10.minutes.ago
-  end
-
-  def account_token_records_fresh?
-    last_sync = account_token_records.synced.order(synced_at: :desc).first&.synced_at
-    last_sync.nil? || last_sync < 10.minutes.ago
-  end
-
   private
 
     def set_values_from_token_type # rubocop:todo Metrics/CyclomaticComplexity

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -111,6 +111,16 @@ class Token < ApplicationRecord
     RegGroup.default_for(self)
   end
 
+  def transfer_rules_fresh?
+    last_sync = transfer_rules.synced.order(synced_at: :desc).first&.synced_at
+    last_sync.nil? || last_sync < 10.minutes.ago
+  end
+
+  def account_token_records_fresh?
+    last_sync = account_token_records.synced.order(synced_at: :desc).first&.synced_at
+    last_sync.nil? || last_sync < 10.minutes.ago
+  end
+
   private
 
     def set_values_from_token_type # rubocop:todo Metrics/CyclomaticComplexity

--- a/app/models/token_type/algorand_security_token.rb
+++ b/app/models/token_type/algorand_security_token.rb
@@ -106,4 +106,16 @@ class TokenType::AlgorandSecurityToken < TokenType
   def default_reg_group
     1
   end
+
+  # ApplicationJob class to perform transfer rule sync
+  # @return [Class] job
+  def transfer_rule_sync_job
+    ::AlgorandSecurityToken::TransferRulesSyncJob
+  end
+
+  # ApplicationJob class to perform account sync
+  # @return [Class] job
+  def accounts_sync_job
+    ::AlgorandSecurityToken::AccountTokenRecordsSyncJob
+  end
 end

--- a/app/models/token_type/algorand_security_token.rb
+++ b/app/models/token_type/algorand_security_token.rb
@@ -100,4 +100,10 @@ class TokenType::AlgorandSecurityToken < TokenType
   def blockchain
     attrs[:blockchain]
   end
+
+  # Default reg group when a record is created
+  # @return [Integer] reg_group
+  def default_reg_group
+    1
+  end
 end

--- a/app/models/token_type/comakery_security_token.rb
+++ b/app/models/token_type/comakery_security_token.rb
@@ -57,4 +57,16 @@ class TokenType::ComakerySecurityToken < TokenType::Erc20
   def default_reg_group
     0
   end
+
+  # ApplicationJob class to perform transfer rule sync
+  # @return [Class] job
+  def transfer_rule_sync_job
+    ::BlockchainJob::ComakerySecurityTokenJob::TransferRulesSyncJob
+  end
+
+  # ApplicationJob class to perform account sync
+  # @return [Class] job
+  def accounts_sync_job
+    nil
+  end
 end

--- a/app/models/token_type/comakery_security_token.rb
+++ b/app/models/token_type/comakery_security_token.rb
@@ -51,4 +51,10 @@ class TokenType::ComakerySecurityToken < TokenType::Erc20
   def supports_token_freeze?
     true
   end
+
+  # Default reg group when a record is created
+  # @return [Integer] reg_group
+  def default_reg_group
+    0
+  end
 end

--- a/app/models/transfer_rule.rb
+++ b/app/models/transfer_rule.rb
@@ -1,5 +1,6 @@
 class TransferRule < ApplicationRecord
   include BlockchainTransactable
+  include Refreshable
 
   belongs_to :token
   belongs_to :sending_group, class_name: 'RegGroup'

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -61,6 +61,6 @@ class Wallet < ApplicationRecord
     end
 
     def empty_address_allowed?
-      ore_id? && wallet_provisions.empty?
+      ore_id? && (wallet_provisions.empty? || wallet_provisions.any?(&:pending?))
     end
 end

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -11,7 +11,7 @@ class Wallet < ApplicationRecord
   has_many :account_token_records, dependent: :destroy
 
   validates :source, presence: true
-  validates :address, presence: true, unless: :pending?
+  validates :address, presence: true, unless: :empty_address_allowed?
   validates :address, blockchain_address: true
   validates :address, uniqueness: { scope: %i[account_id _blockchain], message: 'has already been taken for the blockchain' }
   validates :_blockchain, uniqueness: { scope: %i[account_id primary_wallet], message: 'has primary wallet already' }, if: :primary_wallet?
@@ -31,10 +31,6 @@ class Wallet < ApplicationRecord
     available_blockchains = Blockchain.available
     available_blockchains.reject!(&:supported_by_ore_id?)
     available_blockchains.map(&:key)
-  end
-
-  def pending?
-    ore_id? && ore_id_account&.pending?
   end
 
   def coin_balance
@@ -62,5 +58,9 @@ class Wallet < ApplicationRecord
 
     def blockchain_supported_by_ore_id
       errors.add(:_blockchain, 'is not supported with ore_id source') unless blockchain.supported_by_ore_id?
+    end
+
+    def empty_address_allowed?
+      ore_id? && wallet_provisions.empty?
     end
 end

--- a/app/policies/token_policy.rb
+++ b/app/policies/token_policy.rb
@@ -33,9 +33,4 @@ class TokenPolicy < ApplicationPolicy
   alias edit? new?
   alias update? new?
   alias fetch_contract_details? new?
-
-  def refresh_transfer_rules_enabled?
-    last_synced_transfer_rule = token.transfer_rules.where.not(synced_at: nil).order(synced_at: :desc).first
-    last_synced_transfer_rule.nil? || last_synced_transfer_rule.synced_at < 10.minutes.ago
-  end
 end

--- a/app/views/dashboard/accounts/_account.html.erb
+++ b/app/views/dashboard/accounts/_account.html.erb
@@ -2,14 +2,14 @@
 <% synced_record = account.account_token_records.where(token: @project.token, status: :synced).last %>
 <% last_record = account.account_token_records.where(token: @project.token).last %>
 <% last_record_is_not_synced = synced_record && last_record && synced_record.id != last_record.id %>
-<% form_url = last_record ? project_dashboard_account_path(@project, account) : root_path %>
 
-<% form_data = last_record ? { controller: "account-form", target: "account-form.form", 'account-form-address' => account.address_for_blockchain(@project.token._blockchain), 'account-form-account-id' => account.id, 'account-form-account-token-records-path' => project_dashboard_accounts_path(token_id: @project.token.id), 'account-form-transactions-path' => api_v1_project_blockchain_transactions_path(project_id: @project.id)}.merge(@project.token.decorate.eth_data('account-form')) : nil %>
 <div id="project_<%= @project.id %>_account_<%= account.id %>">
-  <%= form_with model: last_record, url: form_url, method: :get, data: form_data, class: 'account-form' do |f| %>
-    <% if policy(@project).edit_accounts? && last_record && last_record.synced? && account.address_for_blockchain(@project.token._blockchain) %>
-      <%= image_tag 'pencil.svg', data: {action: 'click->account-form#showForm', target: 'account-form.outputs'}, class: 'transfers-table--edit-icon transfers-table--edit-icon__pencil' %>
-      <%= image_tag 'iconCloseDark.svg', data: {action: 'click->account-form#hideForm', target: 'account-form.inputs'}, class: 'transfers-table--edit-icon hidden' %>
+  <%= form_with(last_record.decorate.form_attrs(@project)) do |f| %>
+    <%= f.hidden_field :account_id, value: account.id %>
+
+    <% if policy(@project).edit_accounts? && account.address_for_blockchain(@project.token._blockchain) %>
+      <%= image_tag 'pencil.svg', data: { action: 'click->account-form-controls#showForm', target: 'account-form-controls.outputs' }, class: 'transfers-table--edit-icon transfers-table--edit-icon__pencil' %>
+      <%= image_tag 'iconCloseDark.svg', data: { action: 'click->account-form-controls#hideForm', target: 'account-form-controls.inputs' }, class: 'transfers-table--edit-icon hidden' %>
     <% end %>
 
     <div class="transfers-table__transfer">
@@ -57,7 +57,7 @@
         <div class="transfers-table__transfer__max_balance">
           <label>max balance</label>
 
-          <div data-target="account-form.outputs">
+          <div data-target="account-form-controls.outputs">
             <% if last_record&.max_balance && last_record.max_balance > 0 %>
               <% if last_record_is_not_synced %>
                 <div class="accounts-table_outdated_data">
@@ -70,13 +70,13 @@
             <% end %>
           </div>
 
-          <%= f.number_field(:max_balance, required: false, placeholder: '0', min: @project.step_for_amount_input, step: @project.step_for_amount_input, data: {target: "account-form.addressMaxBalance account-form.inputs", action: "change->account-form#forceInputPrecision"}, class: 'hidden') %>
+          <%= f.number_field(:max_balance, required: false, placeholder: '0', min: @project.step_for_amount_input, step: @project.step_for_amount_input, data: {target: "account-form.addressMaxBalance account-form-controls.inputs", action: "change->account-form#forceInputPrecision"}, class: 'hidden') %>
         </div>
 
         <div class="transfers-table__transfer__lockup_until">
           <label>lockup until</label>
 
-          <div data-target="account-form.outputs">
+          <div data-target="account-form-controls.outputs">
             <% if last_record_is_not_synced %>
               <div class="accounts-table_outdated_data">
                 <%= synced_record&.decorate&.lockup_until_pretty %>
@@ -85,13 +85,13 @@
             <%= last_record&.decorate&.lockup_until_pretty %>
           </div>
 
-          <%= f.date_field(:lockup_until, required: false, placeholder: 'dd.mm.yyyy', data: {target: "account-form.addressLockupUntil account-form.inputs"}, class: 'hidden') %>
+          <%= f.datetime_local_field(:lockup_until, step: 1, required: false, placeholder: 'dd.mm.yyyy', data: {target: "account-form.addressLockupUntil account-form-controls.inputs"}, class: 'hidden') %>
         </div>
 
         <div class="transfers-table__transfer__reg_group">
           <label>reg group</label>
 
-          <div data-target="account-form.outputs">
+          <div data-target="account-form-controls.outputs">
             <% if last_record_is_not_synced %>
               <div class="accounts-table_outdated_data">
                 <%= synced_record&.reg_group ? "#{synced_record.reg_group.name} (#{synced_record.reg_group.blockchain_id})" : "–" %>
@@ -100,13 +100,13 @@
             <%= last_record&.reg_group ? "#{last_record.reg_group.name} (#{last_record.reg_group.blockchain_id})" : "–" %>
           </div>
 
-          <%= f.select(:reg_group_id, @project.token.reg_groups.collect { |g| [ "#{g.name} (#{g.blockchain_id})", g.id ] }, { include_blank: false }, { required: false, class: 'hidden', data: {target: "account-form.addressGroupId account-form.inputs"} }) %>
+          <%= f.select(:reg_group_id, @project.token.reg_groups.collect { |g| [ "#{g.name} (#{g.blockchain_id})", g.id ] }, { include_blank: false }, { required: false, class: 'hidden', data: {target: "account-form.addressGroupId account-form-controls.inputs"} }) %>
         </div>
 
         <div class="transfers-table__transfer__frozen">
           <label>frozen</label>
 
-          <div data-target="account-form.outputs">
+          <div data-target="account-form-controls.outputs">
             <% if last_record_is_not_synced %>
               <div class="accounts-table_outdated_data">
                 <%= synced_record&.account_frozen? ? "Yes" : "No" %>
@@ -120,13 +120,13 @@
             <% end %>
           </div>
 
-          <%= f.select(:account_frozen, [['Yes', true], ['No', false]], { include_blank: false }, { required: false, class: 'hidden', data: {target: "account-form.addressFrozen account-form.inputs"} }) %>
+          <%= f.select(:account_frozen, [['Yes', true], ['No', false]], { include_blank: false }, { required: false, class: 'hidden', data: {target: "account-form.addressFrozen account-form-controls.inputs"} }) %>
         </div>
 
         <div class="transfers-table__transfer__status">
           <label>status</label>
 
-          <div data-target="account-form.outputs">
+          <div data-target="account-form-controls.outputs">
             <% if last_record&.status %>
               <div>
                 <% if last_record.synced? %>
@@ -146,7 +146,7 @@
             <% end %>
           </div>
 
-          <div class="hidden" data-target="account-form.inputs">
+          <div class="hidden" data-target="account-form-controls.inputs">
             –
           </div>
         </div>
@@ -154,13 +154,17 @@
     </div>
 
     <% if policy(@project).edit_accounts? && last_record && account.address_for_blockchain(@project.token._blockchain) %>
-      <div class="transfers-table--edit-save hidden" data-target="account-form.inputs">
+      <div class="transfers-table--edit-save hidden" data-target="account-form-controls.inputs">
         <div class='transfer-button'>
-          <% if @project.token&.token_frozen? %>
+          <% if @project.token.token_frozen? %>
             frozen
-
+          <% elsif @project.token.blockchain.supported_by_ore_id? %>
+            <%= f.button type: :submit, class: 'transfer-algo-btn', data: { turbo: "false" } do %>
+              <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
+              <span>Save</span>
+            <% end %>
           <% else %>
-            <%= link_to 'javascript:void(0)', data: {action: 'account-form#save', target: 'account-form.button account-form.inputs'}, class: 'transfer-tokens-btn transfer-tokens-btn-skip-legacy hidden' do %>
+            <%= link_to 'javascript:void(0)', data: {action: 'account-form#save', target: 'account-form.button account-form-controls.inputs'}, class: 'transfer-tokens-btn transfer-tokens-btn-skip-legacy hidden' do %>
               <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
               <span>Save</span>
             <% end %>

--- a/app/views/dashboard/accounts/index.html.erb
+++ b/app/views/dashboard/accounts/index.html.erb
@@ -3,7 +3,7 @@
 
     <div class="transfer-rules__buttons">
       <div class="transfer-rules__refresh_from_blockchain">
-        <% if policy(@project).edit_accounts? %>
+        <% if policy(@project).edit_accounts? && @project.token.token_type.accounts_sync_job %>
           <%= button_to 'refresh accounts', refresh_from_blockchain_project_dashboard_accounts_path(@project), class: 'transfer-rules__refresh_from_blockchain_button', method: :post, disabled: @project.token.account_token_records.fresh?, data: { disable_with: "..." } %>
         <% end %>
       </div>

--- a/app/views/dashboard/accounts/index.html.erb
+++ b/app/views/dashboard/accounts/index.html.erb
@@ -1,6 +1,14 @@
 <%= render layout: 'projects/project_settings' do %>
     <%= render partial: "filters" %>
 
+    <div class="transfer-rules__buttons">
+      <div class="transfer-rules__refresh_from_blockchain">
+        <% if policy(@project).edit_accounts? %>
+          <%= button_to 'refresh accounts', refresh_from_blockchain_project_dashboard_accounts_path(@project), class: 'transfer-rules__refresh_from_blockchain_button', method: :post, disabled: @project.token.account_token_records.fresh?, data: { disable_with: "..." } %>
+        <% end %>
+      </div>
+    </div>
+
     <div class="transfers-table animated fadeIn faster">
       <%= render partial: "header" %>
       <%= render partial: "summary" %>

--- a/app/views/dashboard/transfer_rules/_form_transfer_rule.html.erb
+++ b/app/views/dashboard/transfer_rules/_form_transfer_rule.html.erb
@@ -1,5 +1,4 @@
-<%= form_with model: TransferRule.new, url: project_dashboard_transfer_rules_path(@project), data: {controller: "transfer-rule-form", target: "transfer-rule-form.form transfer-rules.form", 'transfer-rule-form-transfer-rules-path' => api_v1_project_transfer_rules_path(project_id: @project.id), 'transfer-rule-form-transactions-path' => api_v1_project_blockchain_transactions_path(project_id: @project.id)}.merge(@project.token.decorate.eth_data('transfer-rule-form')), class: 'transfer-rule-form hidden' do |f| %>
-
+<%= form_with(TransferRule.new.decorate.form_attrs(@project)) do |f| %>
   <%= image_tag 'iconCloseDark.svg', data: {action: 'click->transfer-rules#hideForm'}, class: 'transfers-table--edit-icon' %>
 
   <div class="transfers-table__transfer">
@@ -30,15 +29,18 @@
     <% if policy(@project).edit_transfer_rules? %>
       <div class="transfers-table__transfer__action">
         <div class='transfer-button'>
-          <% if @project.token&.token_frozen? %>
+          <% if @project.token.token_frozen? %>
             frozen
-
+          <% elsif @project.token.blockchain.supported_by_ore_id? %>
+            <%= f.button type: :submit, class: 'transfer-algo-btn', data: { turbo: "false" } do %>
+              <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
+              <span>SAVE</span>
+            <% end %>
           <% else %>
             <%= link_to 'javascript:void(0)', data: {action: 'transfer-rule-form#create', target: 'transfer-rule-form.button'}, class: 'transfer-tokens-btn transfer-tokens-btn-skip-legacy' do %>
               <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
               <span>Create</span>
             <% end %>
-
           <% end %>
         </div>
       </div>

--- a/app/views/dashboard/transfer_rules/_form_transfer_rule.html.erb
+++ b/app/views/dashboard/transfer_rules/_form_transfer_rule.html.erb
@@ -23,7 +23,7 @@
     <div class="transfers-table__transfer__lockup_until">
       <label>allowed after date</label>
 
-      <%= f.date_field(:lockup_until, required: true, placeholder: 'dd.mm.yyyy', data: {target: "transfer-rule-form.ruleLockupUntil transfer-rule-form.inputs"}) %>
+      <%= f.datetime_local_field(:lockup_until, step: 1, required: true, placeholder: 'dd.mm.yyyy', data: {target: "transfer-rule-form.ruleLockupUntil transfer-rule-form.inputs"}) %>
     </div>
 
     <% if policy(@project).edit_transfer_rules? %>

--- a/app/views/dashboard/transfer_rules/_freeze_token.html.erb
+++ b/app/views/dashboard/transfer_rules/_freeze_token.html.erb
@@ -1,21 +1,15 @@
 <div class="freeze-token">
-  <% if @project.token.token_frozen %>
-
-    <%= form_with url: unpause_project_dashboard_transfer_rules_path(@project), data: {controller: "freeze-form", target: "freeze-form.form"}.merge(@project.token.decorate.eth_data('freeze-form')), class: 'freeze-token__form transfer-button' do |f| %>
+  <% if @project.token.blockchain.supported_by_ore_id? %>
+    <%= button_to freeze_project_dashboard_transfer_rules_path(@project), class: 'transfer-algo-btn transfer-tokens-btn-freeze', data: { turbo: "false" } do %>
+      <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
+      <span><%= @project.token.token_frozen? ? 'Unfreeze' : 'Freeze' %></span>
+    <% end %>
+  <% else %>
+    <%= form_with url: freeze_project_dashboard_transfer_rules_path(@project), data: {controller: "freeze-form", target: "freeze-form.form"}.merge(@project.token.decorate.eth_data('freeze-form')), class: 'freeze-token__form transfer-button' do |f| %>
       <%= link_to 'javascript:void(0)', data: {action: 'click->freeze-form#unpause', target: 'freeze-form.button'}, class: 'transfer-tokens-btn transfer-tokens-btn-skip-legacy transfer-tokens-btn-freeze' do %>
         <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
-        <span>Unfreeze Token</span>
+        <span><%= @project.token.token_frozen? ? 'Unfreeze' : 'Freeze' %></span>
       <% end %>
     <% end %>
-
-  <% else %>
-
-    <%= form_with url: pause_project_dashboard_transfer_rules_path(@project), data: {controller: "freeze-form", target: "freeze-form.form"}.merge(@project.token.decorate.eth_data('freeze-form')), class: 'freeze-token__form transfer-button' do |f| %>
-      <%= link_to 'javascript:void(0)', data: {action: 'click->freeze-form#pause', target: 'freeze-form.button'}, class: 'transfer-tokens-btn transfer-tokens-btn-skip-legacy transfer-tokens-btn-unfreeze' do %>
-        <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
-        <span>Freeze Token</span>
-      <% end %>
-    <% end %>
-
   <% end %>
 </div>

--- a/app/views/dashboard/transfer_rules/_transfer_rule.html.erb
+++ b/app/views/dashboard/transfer_rules/_transfer_rule.html.erb
@@ -1,5 +1,4 @@
-<%= form_with model: transfer_rule, method: :delete, url: project_dashboard_transfer_rule_path(@project, transfer_rule), data: {controller: "transfer-rule-form", target: "transfer-rule-form.form", 'transfer-rule-form-transfer-rules-path' => api_v1_project_transfer_rules_path(project_id: @project.id), 'transfer-rule-form-transactions-path' => api_v1_project_blockchain_transactions_path(project_id: @project.id)}.merge(transfer_rule.decorate.eth_data).merge(@project.token.decorate.eth_data('transfer-rule-form')), class: 'transfer-rule-form' do |f| %>
-
+<%= form_with(transfer_rule.decorate.form_attrs_del(@project)) do |f| %>
   <div class="transfers-table__transfer <%= transfer_rule.synced? ? nil : 'transfers-table__transfer--processing' %>">
     <div class="transfers-table__transfer__sending_group">
       <label>sending group</label>
@@ -36,7 +35,11 @@
         <div class="transfer-button <%= transfer_rule.synced? ? nil : 'in-progress--metamask in-progress--metamask__paid' %>">
           <% if @project.token&.token_frozen? %>
             frozen
-
+          <% elsif @project.token.blockchain.supported_by_ore_id? %>
+            <%= f.button type: :submit, class: 'transfer-algo-btn', data: { turbo: "false" } do %>
+              <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>
+              <span><%= transfer_rule.synced? ? 'DELETE' : 'PROCESSING' %></span>
+            <% end %>
           <% else %>
             <%= link_to 'javascript:void(0)', data: {action: 'transfer-rule-form#delete', target: 'transfer-rule-form.button'}, class: 'transfer-tokens-btn transfer-tokens-btn-skip-legacy' do %>
               <%= render partial: "shared/wallet_logo", locals: { project: @project, size: 12 } %>

--- a/app/views/dashboard/transfer_rules/_transfer_rules.html.erb
+++ b/app/views/dashboard/transfer_rules/_transfer_rules.html.erb
@@ -12,7 +12,7 @@
 
     <div class="transfer-rules__refresh_from_blockchain">
       <% if policy(@project).refresh_transfer_rules? %>
-        <%= button_to 'refresh transfer rules', refresh_from_blockchain_project_dashboard_transfer_rules_path(@project), class: 'transfer-rules__refresh_from_blockchain_button', method: :post, disabled: !policy(@project.token).refresh_transfer_rules_enabled? %>
+        <%= button_to 'refresh transfer rules', refresh_from_blockchain_project_dashboard_transfer_rules_path(@project), class: 'transfer-rules__refresh_from_blockchain_button', method: :post, disabled: @project.token.transfer_rules.fresh?, data: { disable_with: "..." } %>
       <% end %>
     </div>
   </div>

--- a/app/views/dashboard/transfer_rules/_transfer_rules.html.erb
+++ b/app/views/dashboard/transfer_rules/_transfer_rules.html.erb
@@ -5,7 +5,7 @@
 
   <div class="transfer-rules__buttons">
     <div class="transfer-rules__create">
-      <% if policy(@project).edit_transfer_rules? %>
+      <% if policy(@project).edit_transfer_rules? && @project.token.token_type.transfer_rule_sync_job %>
         <%= button_tag "create transfer rule ＋", type: 'button', class: 'transfer-rule-create', data: { target: 'transfer-rules.button', action: 'transfer-rules#showForm' } %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,11 @@ Rails.application.routes.draw do
 
     namespace :dashboard do
       resources :transfers, only: [:index, :show, :create]
-      resources :accounts, only: [:index, :show, :create]
+      resources :accounts, only: [:index, :show, :create] do
+        collection do
+          post :refresh_from_blockchain
+        end
+      end
       resources :accesses, only: [:index] do
         collection do
           post :regenerate_api_key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,8 +100,7 @@ Rails.application.routes.draw do
       resources :transfer_types, only: [:create, :update, :destroy]
       resources :transfer_rules, only: [:create, :destroy, :index] do
         collection do
-          post :pause
-          post :unpause
+          post :freeze
           post :refresh_from_blockchain
         end
       end
@@ -147,7 +146,7 @@ Rails.application.routes.draw do
   end
 
   namespace :sign, defaults: { format: :json } do
-    post 'ore_id/new'
+    match 'ore_id/new', to: 'ore_id#new', via: [:get, :post]
     get 'ore_id/receive'
   end
 

--- a/spec/controllers/dashboard/accounts_controller_spec.rb
+++ b/spec/controllers/dashboard/accounts_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dashboard::AccountsController, type: :controller do
       }
     end
 
-    subject { post :create, params: { project_id: project.id, body: { data: { account_token_record: attributes } } } }
+    subject { post :create, params: { project_id: project.id, account_token_record: attributes } }
 
     before do
       login(project.account)
@@ -59,14 +59,20 @@ RSpec.describe Dashboard::AccountsController, type: :controller do
         expect(account_token_record.wallet).to eq new_account.wallets.first
       end
 
-      it 'returns created record' do
-        subject
-        expect(response).to have_http_status(:created)
+      context 'with comakery security token' do
+        it 'returns created record' do
+          subject
+          expect(response).to have_http_status(:created)
+        end
       end
 
-      it 'adds record account to project interested' do
-        subject
-        expect(project.interested).to include(AccountTokenRecord.last.account)
+      context 'with algorand security token', :vcr do
+        let(:account_token_record) { create(:blockchain_transaction_account_token_record_algo).blockchain_transactable }
+
+        it 'redirects to ore_id' do
+          subject
+          expect(response).to have_http_status(:found)
+        end
       end
     end
 

--- a/spec/controllers/dashboard/transfer_rules_controller_spec.rb
+++ b/spec/controllers/dashboard/transfer_rules_controller_spec.rb
@@ -1,23 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::TransferRulesController, type: :controller do
-  let!(:token) { create(:token, _token_type: :comakery_security_token, contract_address: build(:ethereum_contract_address), _blockchain: :ethereum_ropsten) }
+  let!(:token) { create(:algo_sec_token, contract_address: '13997710') }
   let!(:project) { create(:project, visibility: :public_listed, token: token) }
-  let!(:transfer_rule) { create(:transfer_rule, token: token) }
 
   before do
     login(project.account)
-  end
-
-  describe 'DELETE #destroy' do
-    context 'with valid params' do
-      it 'destroys a rule' do
-        expect do
-          delete :destroy, params: { id: transfer_rule.id, project_id: project.to_param }
-          expect(response).to redirect_to(project_dashboard_transfer_rules_path(project))
-        end.to change(project.token.transfer_rules, :count).by(-1)
-      end
-    end
   end
 
   describe 'GET #index' do
@@ -27,27 +15,83 @@ RSpec.describe Dashboard::TransferRulesController, type: :controller do
     end
   end
 
-  describe 'POST #pause' do
-    context 'with valid params' do
-      it 'pauses token' do
-        project.token.update(token_frozen: false)
+  describe 'POST #create' do
+    let(:valid_attributes) do
+      {
+        sending_group_id: RegGroup.find_or_create_by!(token_id: token.id, blockchain_id: 100),
+        receiving_group_id: RegGroup.find_or_create_by!(token_id: token.id, blockchain_id: 200),
+        lockup_until: 1
+      }
+    end
 
-        post :pause, params: { project_id: project.to_param }
-        expect(response).to redirect_to(project_dashboard_transfer_rules_path(project))
-        expect(project.token.reload.token_frozen?).to be_truthy
+    let(:invalid_attributes) do
+      {
+        sending_group_id: 0,
+        receiving_group_id: 100,
+        lockup_until: 'dummy'
+      }
+    end
+
+    subject { post :create, params: { project_id: project.id, transfer_rule: attributes } }
+
+    context 'with valid params' do
+      let(:attributes) { valid_attributes }
+
+      it 'creates a new record' do
+        expect { subject }.to change(project.token.transfer_rules, :count).by(1)
+      end
+
+      context 'with algorand security token', :vcr do
+        it 'redirects to ore_id' do
+          subject
+          expect(response).to have_http_status(:found)
+        end
+      end
+    end
+
+    context 'with invalid params' do
+      let(:attributes) { invalid_attributes }
+
+      it 'doesnt create a new record' do
+        expect { subject }.not_to change(project.token.transfer_rules, :count)
+      end
+
+      context 'with algorand security token', :vcr do
+        it 'redirects to index' do
+          subject
+          expect(response).to redirect_to(project_dashboard_transfer_rules_path(project))
+        end
       end
     end
   end
 
-  describe 'POST #unpause' do
-    context 'with valid params' do
-      it 'unpauses token' do
-        project.token.update(token_frozen: true)
+  describe 'DELETE #destroy' do
+    let!(:transfer_rule) { create(:transfer_rule, token: token) }
+    subject { delete :destroy, params: { project_id: project.id, id: transfer_rule.id } }
 
-        post :unpause, params: { project_id: project.to_param }
-        expect(response).to redirect_to(project_dashboard_transfer_rules_path(project))
-        expect(project.token.reload.token_frozen?).to be_falsey
+    it 'creates a new record with 0 lockup_until' do
+      expect { subject }.to change(project.token.transfer_rules, :count).by(1)
+
+      new_rule = project.token.transfer_rules.last
+      expect(new_rule.sending_group_id).to eq(transfer_rule.sending_group_id)
+      expect(new_rule.receiving_group_id).to eq(transfer_rule.receiving_group_id)
+      expect(new_rule.lockup_until).to eq(Time.zone.at(0))
+    end
+
+    context 'with algorand security token', :vcr do
+      it 'redirects to ore_id' do
+        subject
+        expect(response).to have_http_status(:found)
       end
+    end
+  end
+
+  describe 'POST #freeze' do
+    subject { post :freeze, params: { project_id: project.id } }
+
+    it 'redirects to ore_id' do
+      subject
+      expect(response).to have_http_status(:found)
     end
   end
 

--- a/spec/decorators/account_token_record_decorator_spec.rb
+++ b/spec/decorators/account_token_record_decorator_spec.rb
@@ -1,6 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe AccountTokenRecordDecorator do
+  describe 'form_attrs' do
+    subject { transfer_rule.decorate.form_attrs(project) }
+
+    context 'with comakery security token' do
+      let(:transfer_rule) { create(:account_token_record) }
+      let(:project) { create(:project, token: transfer_rule.token) }
+
+      it { is_expected.to be_a(Hash) }
+    end
+
+    context 'with algorand security token', :vcr do
+      let(:transfer_rule) { create(:algo_sec_dummy_restrictions) }
+      let(:project) { create(:project, token: transfer_rule.token) }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
   describe 'lockup_until_pretty' do
     let!(:account_token_record_max_lockup) { create(:account_token_record, lockup_until: 101.years.from_now) }
     let!(:account_token_record_min_lockup) { create(:account_token_record, lockup_until: AccountTokenRecord::LOCKUP_UNTIL_MIN) }

--- a/spec/decorators/transfer_rule_decorator_spec.rb
+++ b/spec/decorators/transfer_rule_decorator_spec.rb
@@ -1,6 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe TransferRuleDecorator do
+  describe 'form_attrs' do
+    subject { transfer_rule.decorate.form_attrs(project) }
+
+    context 'with comakery security token' do
+      let(:transfer_rule) { create(:transfer_rule) }
+      let(:project) { create(:project, token: transfer_rule.token) }
+
+      it { is_expected.to be_a(Hash) }
+    end
+
+    context 'with algorand security token', :vcr do
+      let(:transfer_rule) { create(:algo_sec_dummy_transfer_rule) }
+      let(:project) { create(:project, token: transfer_rule.token) }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
+  describe 'form_attrs_del' do
+    subject { transfer_rule.decorate.form_attrs_del(project) }
+
+    context 'with comakery security token' do
+      let(:transfer_rule) { create(:transfer_rule) }
+      let(:project) { create(:project, token: transfer_rule.token) }
+
+      it { is_expected.to be_a(Hash) }
+    end
+
+    context 'with algorand security token', :vcr do
+      let(:transfer_rule) { create(:algo_sec_dummy_transfer_rule) }
+      let(:project) { create(:project, token: transfer_rule.token) }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
   describe 'eth_data' do
     let!(:transfer_rule) { create(:transfer_rule) }
 

--- a/spec/jobs/algorand_security_token/account_token_records_sync_job_spec.rb
+++ b/spec/jobs/algorand_security_token/account_token_records_sync_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe AlgorandSecurityToken::AccountTokenRecordsSyncJob, type: :job, vcr: true do
+  let(:token) { create(:algo_sec_token, contract_address: '13997710') }
+  subject { described_class.perform_now(token) }
+
+  context 'with opted in wallets' do
+    let!(:wallet) { create(:wallet, _blockchain: :algorand_test, address: 'QLL4PEGFO7MGQJGUOPUT3MANOI2U3TG5YF3ZM66FPF4GMORTIKPHOYIGSI') }
+    let!(:opt_in) { create(:token_opt_in, wallet: wallet, token: token, status: :opted_in) }
+
+    it 'creates account token records' do
+      expect { subject }.to change(token.account_token_records, :count).by(1)
+
+      expect(token.account_token_records.synced.where(
+               wallet: wallet,
+               account: wallet.account,
+               lockup_until: 1614299570,
+               max_balance: 22000000000,
+               reg_group: RegGroup.find_by(token: token, blockchain_id: 1),
+               account_frozen: false
+             )).not_to be_empty
+    end
+
+    it 'creates balances' do
+      expect { subject }.to change(wallet.balances, :count).by(1)
+
+      expect(wallet.balances.where(
+               token: token,
+               base_unit_value: 106250051
+             )).not_to be_empty
+    end
+  end
+end

--- a/spec/jobs/algorand_security_token/transfer_rules_sync_job_spec.rb
+++ b/spec/jobs/algorand_security_token/transfer_rules_sync_job_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe AlgorandSecurityToken::TransferRulesSyncJob, type: :job, vcr: true do
+  let(:token) { create(:algo_sec_token, contract_address: '13997710') }
+  subject { described_class.perform_now(token) }
+
+  it 'creates transfer rules' do
+    expect { subject }.to change(token.transfer_rules, :count).by(3)
+
+    expect(token.transfer_rules.synced.where(
+             lockup_until: 1,
+             sending_group: RegGroup.find_by(token: token, blockchain_id: 1),
+             receiving_group: RegGroup.find_by(token: token, blockchain_id: 1)
+           )).not_to be_empty
+
+    expect(token.transfer_rules.synced.where(
+             lockup_until: 2021,
+             sending_group: RegGroup.find_by(token: token, blockchain_id: 2),
+             receiving_group: RegGroup.find_by(token: token, blockchain_id: 2)
+           )).not_to be_empty
+
+    expect(token.transfer_rules.synced.where(
+             lockup_until: 1614129708,
+             sending_group: RegGroup.find_by(token: token, blockchain_id: 2),
+             receiving_group: RegGroup.find_by(token: token, blockchain_id: 1)
+           )).not_to be_empty
+  end
+end

--- a/spec/models/account_token_record_spec.rb
+++ b/spec/models/account_token_record_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'models/concerns/refreshable_spec'
 
 describe AccountTokenRecord do
+  it_behaves_like 'refreshable'
+
   describe 'associations' do
     let(:token) { create(:token, _token_type: :comakery_security_token, contract_address: build(:ethereum_contract_address), _blockchain: :ethereum_ropsten) }
     let(:reg_group) { create(:reg_group, token: token) }

--- a/spec/models/blockchain_transaction_account_token_record_spec.rb
+++ b/spec/models/blockchain_transaction_account_token_record_spec.rb
@@ -15,6 +15,14 @@ describe BlockchainTransactionAccountTokenRecord, vcr: true do
     end
   end
 
+  describe 'populate_data' do
+    subject { create(:blockchain_transaction_account_token_record) }
+
+    it 'populates' do
+      expect(subject.destination).to eq(subject.blockchain_transactable.wallet.address)
+    end
+  end
+
   describe 'on_chain' do
     context 'with comakery security token' do
       subject { build(:blockchain_transaction_account_token_record).on_chain }

--- a/spec/models/concerns/refreshable_spec.rb
+++ b/spec/models/concerns/refreshable_spec.rb
@@ -1,0 +1,27 @@
+shared_examples 'refreshable' do
+  describe 'fresh?' do
+    subject { described_class.fresh? }
+
+    context 'without synced records' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'with synced records' do
+      context 'synced more that 10 mins ago' do
+        before do
+          create(described_class.to_s.underscore.to_sym, status: :synced, synced_at: 11.minutes.ago)
+        end
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'synced more less 10 mins ago' do
+        before do
+          create(described_class.to_s.underscore.to_sym, status: :synced, synced_at: 2.minutes.ago)
+        end
+
+        it { is_expected.to be_truthy }
+      end
+    end
+  end
+end

--- a/spec/models/token_type/algorand_security_token_spec.rb
+++ b/spec/models/token_type/algorand_security_token_spec.rb
@@ -19,6 +19,7 @@ describe TokenType::AlgorandSecurityToken, vcr: true do
   specify { expect(described_class.new(**attrs).supports_token_mint?).to be_truthy }
   specify { expect(described_class.new(**attrs).supports_token_burn?).to be_truthy }
   specify { expect(described_class.new(**attrs).supports_token_freeze?).to be_truthy }
+  specify { expect(described_class.new(**attrs).default_reg_group).to eq(1) }
 
   describe 'contract' do
     context 'when contract_address is invalid' do

--- a/spec/models/token_type/algorand_security_token_spec.rb
+++ b/spec/models/token_type/algorand_security_token_spec.rb
@@ -20,6 +20,8 @@ describe TokenType::AlgorandSecurityToken, vcr: true do
   specify { expect(described_class.new(**attrs).supports_token_burn?).to be_truthy }
   specify { expect(described_class.new(**attrs).supports_token_freeze?).to be_truthy }
   specify { expect(described_class.new(**attrs).default_reg_group).to eq(1) }
+  specify { expect(described_class.new(**attrs).transfer_rule_sync_job).to eq(AlgorandSecurityToken::TransferRulesSyncJob) }
+  specify { expect(described_class.new(**attrs).accounts_sync_job).to eq(AlgorandSecurityToken::AccountTokenRecordsSyncJob) }
 
   describe 'contract' do
     context 'when contract_address is invalid' do

--- a/spec/models/token_type/comakery_security_token_spec.rb
+++ b/spec/models/token_type/comakery_security_token_spec.rb
@@ -16,4 +16,6 @@ describe TokenType::ComakerySecurityToken, vcr: true do
   specify { expect(described_class.new(**attrs).supports_token_burn?).to be_truthy }
   specify { expect(described_class.new(**attrs).supports_token_freeze?).to be_truthy }
   specify { expect(described_class.new(**attrs).default_reg_group).to eq(0) }
+  specify { expect(described_class.new(**attrs).transfer_rule_sync_job).to eq(BlockchainJob::ComakerySecurityTokenJob::TransferRulesSyncJob) }
+  specify { expect(described_class.new(**attrs).accounts_sync_job).to be_nil }
 end

--- a/spec/models/token_type/comakery_security_token_spec.rb
+++ b/spec/models/token_type/comakery_security_token_spec.rb
@@ -15,4 +15,5 @@ describe TokenType::ComakerySecurityToken, vcr: true do
   specify { expect(described_class.new(**attrs).supports_token_mint?).to be_truthy }
   specify { expect(described_class.new(**attrs).supports_token_burn?).to be_truthy }
   specify { expect(described_class.new(**attrs).supports_token_freeze?).to be_truthy }
+  specify { expect(described_class.new(**attrs).default_reg_group).to eq(0) }
 end

--- a/spec/models/transfer_rule_spec.rb
+++ b/spec/models/transfer_rule_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'models/concerns/refreshable_spec'
 
 describe TransferRule do
+  it_behaves_like 'refreshable'
+
   describe 'associations' do
     let!(:token) { create(:token, _token_type: :comakery_security_token, contract_address: build(:ethereum_contract_address), _blockchain: :ethereum_ropsten) }
     let!(:sending_group) { create(:reg_group, token: token) }

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -62,8 +62,15 @@ describe Wallet, type: :model do
       it { is_expected.not_to validate_presence_of(:address) }
     end
 
+    context 'and there is a pending wallet_provision' do
+      let(:wallet_provision) { create(:wallet_provision, state: :pending) }
+      subject { wallet_provision.wallet }
+
+      it { is_expected.not_to validate_presence_of(:address) }
+    end
+
     context 'and wallet_provisions are not empty' do
-      let(:wallet_provision) { create(:wallet_provision) }
+      let(:wallet_provision) { create(:wallet_provision, state: :provisioned) }
       subject { wallet_provision.wallet }
 
       it { is_expected.to validate_presence_of(:address) }

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -58,8 +58,15 @@ describe Wallet, type: :model do
       expect(subject.errors).not_to be_empty
     end
 
-    context 'and ore_id_account is pending' do
+    context 'and wallet_provisions are empty' do
       it { is_expected.not_to validate_presence_of(:address) }
+    end
+
+    context 'and wallet_provisions are not empty' do
+      let(:wallet_provision) { create(:wallet_provision) }
+      subject { wallet_provision.wallet }
+
+      it { is_expected.to validate_presence_of(:address) }
     end
 
     context 'and ore_id_account is unlinking' do

--- a/spec/policies/token_policy_spec.rb
+++ b/spec/policies/token_policy_spec.rb
@@ -29,25 +29,4 @@ describe TokenPolicy do
       end
     end
   end
-
-  describe '#refresh_transfer_rules_enabled?' do
-    let(:account) { create(:account) }
-    let!(:token) { create(:token, _token_type: :comakery_security_token, symbol: 'TEST', contract_address: '0x1D1592c28FFF3d3E71b1d29E31147846026A0a37', decimal_places: 1) }
-
-    specify 'no transfer rules' do
-      expect(described_class.new(account, token).refresh_transfer_rules_enabled?).to be true
-    end
-
-    specify 'transfer rule synced more than 10 minutes ago' do
-      create(:transfer_rule, token: token, status: 'synced', synced_at: 11.minutes.ago)
-
-      expect(described_class.new(account, token).refresh_transfer_rules_enabled?).to be true
-    end
-
-    specify 'transfer rule synced less than 10 minutes ago' do
-      create(:transfer_rule, token: token, status: 'synced', synced_at: 9.minutes.ago)
-
-      expect(described_class.new(account, token).refresh_transfer_rules_enabled?).to be false
-    end
-  end
 end

--- a/spec/support/mom.rb
+++ b/spec/support/mom.rb
@@ -892,7 +892,7 @@ class Mom
     AccountTokenRecord.create(
       account: contributor,
       token: project.token,
-      reg_group: create(:reg_group, blockchain_id: reg_group, token: project.token),
+      reg_group: RegGroup.find_or_create_by!(token_id: project.token.id, blockchain_id: reg_group),
       max_balance: max_balance,
       balance: 0,
       account_frozen: frozen,
@@ -902,12 +902,12 @@ class Mom
 
   def algo_sec_dummy_transfer_rule(from: 0, to: 0, lockup_until: 0)
     project, _admin, _contributor = algo_sec_project_dummy_setup
-    gr_from = create(:reg_group, token: project.token, blockchain_id: from)
+    gr_from = RegGroup.find_or_create_by!(token_id: project.token.id, blockchain_id: from)
 
     gr_to = if from == to
       gr_from
     else
-      create(:reg_group, token: project.token, blockchain_id: to)
+      RegGroup.find_or_create_by!(token_id: project.token.id, blockchain_id: to)
     end
 
     TransferRule.new(

--- a/spec/vcr/AlgorandSecurityToken_AccountTokenRecordsSyncJob/with_opted_in_wallets/creates_account_token_records.yml
+++ b/spec/vcr/AlgorandSecurityToken_AccountTokenRecordsSyncJob/with_opted_in_wallets/creates_account_token_records.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/idx2/v2/accounts/QLL4PEGFO7MGQJGUOPUT3MANOI2U3TG5YF3ZM66FPF4GMORTIKPHOYIGSI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Feb 2021 19:13:22 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=da4b9c2612b079348f2588c8b120469451614021202; expires=Wed, 24-Mar-21
+        19:13:22 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '086cc22a240000323cdba97000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=OR%2FG4WfXUFG04EXQIiTrDEwwWB77%2BpY2KBGdk7GP8GCJvsc0R2h4edpRLBmap%2Botv6xgFNSeHlYvKVjZA0ScHfXWJQSmUAUfJj%2BfCE7XRPgtjMH0Hlj%2BleULymo%3D"}]}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 625b06236d08323c-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"account":{"address":"QLL4PEGFO7MGQJGUOPUT3MANOI2U3TG5YF3ZM66FPF4GMORTIKPHOYIGSI","amount":100212500,"amount-without-pending-rewards":100204000,"apps-local-state":[{"id":13258116,"key-value":[{"key":"YmFsYW5jZQ==","value":{"bytes":"","type":2,"uint":0}},{"key":"dHJhbnNmZXIgZ3JvdXA=","value":{"bytes":"","type":2,"uint":1}}],"schema":{"num-byte-slice":0,"num-uint":4}},{"id":13997710,"key-value":[{"key":"YmFsYW5jZQ==","value":{"bytes":"","type":2,"uint":106250051}},{"key":"bG9ja1VudGls","value":{"bytes":"","type":2,"uint":1614299570}},{"key":"bWF4QmFsYW5jZQ==","value":{"bytes":"","type":2,"uint":22000000000}},{"key":"dHJhbnNmZXJHcm91cA==","value":{"bytes":"","type":2,"uint":1}},{"key":"ZnJvemVu","value":{"bytes":"","type":2,"uint":0}},{"key":"cm9sZXM=","value":{"bytes":"","type":2,"uint":15}}],"schema":{"num-byte-slice":8,"num-uint":8}}],"pending-rewards":8500,"reward-base":26445,"rewards":0,"round":12509999,"sig-type":"sig","status":"Offline"},"current-round":12509999}
+
+'
+    http_version: null
+  recorded_at: Mon, 22 Feb 2021 19:13:22 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/AlgorandSecurityToken_AccountTokenRecordsSyncJob/with_opted_in_wallets/creates_balances.yml
+++ b/spec/vcr/AlgorandSecurityToken_AccountTokenRecordsSyncJob/with_opted_in_wallets/creates_balances.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/idx2/v2/accounts/QLL4PEGFO7MGQJGUOPUT3MANOI2U3TG5YF3ZM66FPF4GMORTIKPHOYIGSI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Feb 2021 19:13:23 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dfcf067e0e0c5730f26e6f098156294921614021203; expires=Wed, 24-Mar-21
+        19:13:23 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '086cc22c99000005cc719e6000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=AJTttakUArfpASoU46jLQ4y3U4udMsm%2FQl%2FVUmTxPTedvqq4DaGY2akz8iW5qWuhCyYH2TMz4gIWA7oujrN7kRAzDWQj%2BIrAyAjDPOVdW8%2BNl5x2%2FcGg6IgGMbw%3D"}],"max_age":604800,"group":"cf-nel"}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 625b06275a7805cc-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"account":{"address":"QLL4PEGFO7MGQJGUOPUT3MANOI2U3TG5YF3ZM66FPF4GMORTIKPHOYIGSI","amount":100212500,"amount-without-pending-rewards":100204000,"apps-local-state":[{"id":13258116,"key-value":[{"key":"YmFsYW5jZQ==","value":{"bytes":"","type":2,"uint":0}},{"key":"dHJhbnNmZXIgZ3JvdXA=","value":{"bytes":"","type":2,"uint":1}}],"schema":{"num-byte-slice":0,"num-uint":4}},{"id":13997710,"key-value":[{"key":"YmFsYW5jZQ==","value":{"bytes":"","type":2,"uint":106250051}},{"key":"bG9ja1VudGls","value":{"bytes":"","type":2,"uint":1614299570}},{"key":"bWF4QmFsYW5jZQ==","value":{"bytes":"","type":2,"uint":22000000000}},{"key":"dHJhbnNmZXJHcm91cA==","value":{"bytes":"","type":2,"uint":1}},{"key":"ZnJvemVu","value":{"bytes":"","type":2,"uint":0}},{"key":"cm9sZXM=","value":{"bytes":"","type":2,"uint":15}}],"schema":{"num-byte-slice":8,"num-uint":8}}],"pending-rewards":8500,"reward-base":26445,"rewards":0,"round":12510000,"sig-type":"sig","status":"Offline"},"current-round":12510000}
+
+'
+    http_version: null
+  recorded_at: Mon, 22 Feb 2021 19:13:23 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/AlgorandSecurityToken_TransferRulesSyncJob/creates_transfer_rules.yml
+++ b/spec/vcr/AlgorandSecurityToken_TransferRulesSyncJob/creates_transfer_rules.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/idx2/v2/applications/13997710
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Feb 2021 17:44:05 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d0ba4e41caa53dad4b1913ea41c8458951614015844; expires=Wed, 24-Mar-21
+        17:44:04 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '086c7069230000324006271000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"group":"cf-nel","endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=EogBAHEJTP4bkeFVvT%2BsiOuopPqsPhKyUnR2rf8HC0n4aDHrmFMHqE%2FrsHQZ2syiB1dCELj5QQlm%2BOYSdjsKF2fj5rAu4ZSRiEKYnMs9aZJEsh3bqKWPKPr2Oxo%3D"}],"max_age":604800}'
+      Nel:
+      - '{"max_age":604800,"report_to":"cf-nel"}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 625a83550b263240-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"application":{"id":13997710,"params":{"approval-program":"AiAHAAUEAgEPCCYWBXBhdXNlCmdyYW50Um9sZXMPc2V0VHJhbnNmZXJSdWxlFXNldEFkZHJlc3NQZXJtaXNzaW9ucwRtaW50BGJ1cm4IdHJhbnNmZXIGZGV0ZWN0C3RvdGFsU3VwcGx5A2NhcAdyZXNlcnZlBnBhdXNlZAhkZWNpbWFscwZzeW1ib2wEbmFtZQ10cmFuc2Zlckdyb3VwB2JhbGFuY2UFcm9sZXMKbWF4QmFsYW5jZQlsb2NrVW50aWwEcnVsZQZmcm96ZW4xGCISQABiMRkjEkAAmzEZJBJAAJkxGSUSQACdMRkhBBJAAJo2GgAoEkAArTYaACkSQAC3NhoAKhJAAOs2GgArEkABBjYaACcEEkABODYaACcFEkABjjYaACcGEkAByjYaACcHEkACSQAnCCJnJwk2GgAXZycKNhoAF2cnCyJnJww2GgEXZycNNhoCZycONhoDZyInDyEEZiInECJmIicRIQVmIQRDQgJsIkNCAmciJxFiIQYaQ0ICXCJDQgJXIicQImYiJxIiZiInEyJmIicPIQRmIQRDQgI8Jws2GgEXZyInEWIhBhpDQgIqIicRYiEGGjEdIQQSEDYaARchBQ4QQAABADEANhwBEkEACzYaARchBhpAAAEAIQQnETYaARdmIQRDQgHuIicRYiUaQAABACcUNhoBFxZQNhoCFxZQNhoDF2chBENCAcsiJxFiIQQaMR0hBBIQQAABACEEJxU2GgEXZiEEJxI2GgIXZiEEJxM2GgMXZiEEJw82GgQXZiEEQ0IBkCInEWIkGjEdIQQSEDYaARcnCmQOEEAAAQAhBCcSYiISIQQnEmIhBCcQYjYaARcIDxFAAAEAJwonCmQ2GgEXCWchBCcQIQQnEGI2GgEXCGYnCCcJZCcKZAlnIQRDQgExIicRYiQaMR0hBBIQNhoBFyEEJxBiDhBAAAEAJwonCmQ2GgEXCGchBCcQIQQnEGI2GgEXCWYnCCcJZCcKZAlnIQRDQgDsMR0hBBIiJxBiNhoBFwwnC2QRIicVYhEiJxNiMgcPEScUIicPYhZQIQQnD2IWUGQhBAwRJxQiJw9iFlAhBCcPYhZQZDIHDxEhBCcSYiINIQQnEmIhBCcQYjYaARcIDBARFBBAAAEAIicQIicQYjYaARcJZiEEJxAhBCcQYjYaARcIZiEEQ0IAZCEEJxBiNhoBFwwnC2QRIQQnFWIRIQQnE2IyBw8RJxQhBCcPYhZQJScPYhZQZCEEDBEnFCEEJw9iFlAlJw9iFlBkMgcPESEEJxJiIg0lJxJiJScQYjYaARcIDBARFEAAAQAhBEM=","clear-state-program":"AiACAAEmBAdyZXNlcnZlB2JhbGFuY2ULdG90YWxTdXBwbHkDY2FwKChkIiliCGcqK2QoZAlnI0M=","creator":"IKSNMZFYNMXFBWB2JCPMEC4HT7UECC354UDCKNHQTNKF7WQG3UQW7YZHWA","global-state":[{"key":"Y2Fw","value":{"bytes":"","type":2,"uint":80000000000000000}},{"key":"ZGVjaW1hbHM=","value":{"bytes":"","type":2,"uint":8}},{"key":"bmFtZQ==","value":{"bytes":"VGhlIFhZWiBUZXN0IFRva2Vu","type":1,"uint":0}},{"key":"cGF1c2Vk","value":{"bytes":"","type":2,"uint":0}},{"key":"cmVzZXJ2ZQ==","value":{"bytes":"","type":2,"uint":79999998893749429}},{"key":"c3ltYm9s","value":{"bytes":"QUJDVEVTVA==","type":1,"uint":0}},{"key":"dG90YWxTdXBwbHk=","value":{"bytes":"","type":2,"uint":1106250571}},{"key":"cnVsZQAAAAAAAAABAAAAAAAAAAE=","value":{"bytes":"","type":2,"uint":1}},{"key":"cnVsZQAAAAAAAAACAAAAAAAAAAI=","value":{"bytes":"","type":2,"uint":2021}},{"key":"cnVsZQAAAAAAAAABAAAAAAAAAAI=","value":{"bytes":"","type":2,"uint":0}},{"key":"cnVsZQAAAAAAAAACAAAAAAAAAAE=","value":{"bytes":"","type":2,"uint":1614129708}}],"global-state-schema":{"num-byte-slice":54,"num-uint":10},"local-state-schema":{"num-byte-slice":8,"num-uint":8}}},"current-round":12508741}
+
+'
+    http_version: null
+  recorded_at: Mon, 22 Feb 2021 17:44:05 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/BlockchainTransactionAccountTokenRecord/on_chain/with_algorand_security_token/1_3_2_1.yml
+++ b/spec/vcr/BlockchainTransactionAccountTokenRecord/on_chain/with_algorand_security_token/1_3_2_1.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 00:03:44 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d365bd224402b108b15ce3d9dd7241e1f1613779424; expires=Mon, 22-Mar-21
+        00:03:44 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085e58eb350000d7296c1e0000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"group":"cf-nel","endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=L%2BSrICl9y5Ux0JRjFE3x23ouilfwsmTKftb%2Fstw18Vnov%2BeDvGmhP7Ycoa0uN1329pconP6TqzAJ8U8hb1729G8NnD2HUPtQeAmErnSz6%2Bh2ELAtdMJOETaV%2FJU%3D"}],"max_age":604800}'
+      Nel:
+      - '{"max_age":604800,"report_to":"cf-nel"}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6243f7585b58d729-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12450000#CGD2TFVZKAXHJ3JPB5JYBCR2BAEX4BX6IOLJ4MP7VZWHNXNY2NXQ","last-round":12453483,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12453484,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":1323394209}
+
+'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 00:03:44 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Dashboard_AccountsController/POST_create/with_valid_params/with_algorand_security_token/redirects_to_ore_id.yml
+++ b/spec/vcr/Dashboard_AccountsController/POST_create/with_valid_params/with_algorand_security_token/redirects_to_ore_id.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 02:26:08 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d617d2a208fc5c1ecbab42a397c343e831613787968; expires=Mon, 22-Mar-21
+        02:26:08 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085edb4baa00004df41c3df000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=wUDhTMU9ovBNizc8ZOYFHs0sN8AadnEX0nhct853%2Fvjidx7%2FIRHi2gqYyo4icnAfW3mMrRIaB7%2BQ81deawTdsEdFBW4XktzTx9sM%2BAcwVnT0jn%2FesPfF3RUh%2FwY%3D"}],"max_age":604800,"group":"cf-nel"}'
+      Nel:
+      - '{"max_age":604800,"report_to":"cf-nel"}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6244c7f2ab2f4df4-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12450000#CGD2TFVZKAXHJ3JPB5JYBCR2BAEX4BX6IOLJ4MP7VZWHNXNY2NXQ","last-round":12455485,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12455486,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":3131666150}
+
+'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 02:26:08 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Dashboard_AccountsController/POST_refresh_from_blockchain/when_accounts_have_not_been_refreshed_recently/with_algorand_security_token/runs_refresh_job.yml
+++ b/spec/vcr/Dashboard_AccountsController/POST_refresh_from_blockchain/when_accounts_have_not_been_refreshed_recently/with_algorand_security_token/runs_refresh_job.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Feb 2021 20:56:03 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d0238ca10c0a2783c9f78fba1d888a73b1614027363; expires=Wed, 24-Mar-21
+        20:56:03 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '086d202e4900002c3acc39b000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"group":"cf-nel","endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=jeZVIA%2BT9neHxhKa%2F79qIh47V%2B5wmM8k4HB%2FHIHwBhr%2By8Wv3XQPRVOQmTemBx%2Fb7ftdQ2dpRtyYkJy27mVcW8w6Jv9PWdnn1vZLGAeXHEciQ4K7TSNEzghHWXQ%3D"}],"max_age":604800}'
+      Nel:
+      - '{"max_age":604800,"report_to":"cf-nel"}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 625b9c907efb2c3a-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12510000#BR67DNDEGYVRYH453FNVWVUVTBDXHRAQT2UNS7RYG2LSTRLQ3PLQ","last-round":12511443,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12511444,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":1307859130}
+
+'
+    http_version: null
+  recorded_at: Mon, 22 Feb 2021 20:56:03 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Dashboard_AccountsController/POST_refresh_from_blockchain/with_algorand_security_token/runs_refresh_job.yml
+++ b/spec/vcr/Dashboard_AccountsController/POST_refresh_from_blockchain/with_algorand_security_token/runs_refresh_job.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Feb 2021 17:29:06 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d5bb0113d88cae8eed45d2c6ba1396b321614014946; expires=Wed, 24-Mar-21
+        17:29:06 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '086c62b3cc0000d6d9b331c000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=yEZeZ%2BDBOyMDeKJKHZAf7Nhdj9ndgAMVWy48qHPvbnyndLM8qoQt%2BEhzgwwtdCkJZEjyy%2BebfeCH%2FV2KJZudvfhoinBU47%2FpoLfzBpTv7MhmoV8QWK503FuJ6Po%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 625a6d6618e2d6d9-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12500000#QB4AVPO6SASGGME22CG44W43EKG5FM3TVN7XUIXRABA5WP6XEVTA","last-round":12508533,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12508534,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":2243886613}
+
+'
+    http_version: null
+  recorded_at: Mon, 22 Feb 2021 17:29:06 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Sign_OreIdController/GET_/new/with_a_frozen_token/creates_a_correct_BlockchainTransaction.yml
+++ b/spec/vcr/Sign_OreIdController/GET_/new/with_a_frozen_token/creates_a_correct_BlockchainTransaction.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 03:31:51 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=de78a8389423ce4fc12a06877ba7595c31613791910; expires=Mon, 22-Mar-21
+        03:31:50 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085f17744900004e92b4361000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"max_age":604800,"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=xQE9nLfI9yAA0ROMCfJ3bWhnkE248l0zv6yqwDt1ewonoO2QIGTzs5ZG9ApcK4ug1cl4SAy4LwWmTzoEEoli%2FVuapVc3RpOA4HyhB009LoLygOJld0Ui%2FjwtfeU%3D"}],"group":"cf-nel"}'
+      Nel:
+      - '{"max_age":604800,"report_to":"cf-nel"}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 62452833ae454e92-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12450000#CGD2TFVZKAXHJ3JPB5JYBCR2BAEX4BX6IOLJ4MP7VZWHNXNY2NXQ","last-round":12456409,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12456410,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":3450720500}
+
+'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 03:31:51 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Sign_OreIdController/GET_/new/with_a_token/creates_a_correct_BlockchainTransaction.yml
+++ b/spec/vcr/Sign_OreIdController/GET_/new/with_a_token/creates_a_correct_BlockchainTransaction.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 03:31:50 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d94a6eacb9055d2cd3bb3653ef4ab16b81613791909; expires=Mon, 22-Mar-21
+        03:31:49 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085f17702800004a565ba44000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=DiV%2FA00MBqttQEY6FCXVBOgTx1JOFkOxkY0DaHAYKUPdHsZH2RVfRs%2BwpcWloRmukNhxSgwI60snO%2F4BvNJAO5VnlxrrGHGN7f4miBPNRYYcpwbB9ajSrAA0uLY%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"max_age":604800,"report_to":"cf-nel"}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6245282d0ca04a56-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12450000#CGD2TFVZKAXHJ3JPB5JYBCR2BAEX4BX6IOLJ4MP7VZWHNXNY2NXQ","last-round":12456409,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12456410,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":2390031125}
+
+'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 03:31:50 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Sign_OreIdController/GET_/new/with_account_token_record/creates_a_correct_BlockchainTransaction.yml
+++ b/spec/vcr/Sign_OreIdController/GET_/new/with_account_token_record/creates_a_correct_BlockchainTransaction.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 03:31:48 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=ddf96410e067dd2a549d8cc4f119db5e91613791908; expires=Mon, 22-Mar-21
+        03:31:48 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085f1769e900004e68da3f7000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"group":"cf-nel","endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=BHzw%2BrKOktzjc048%2BCEBYyIj1gUgyhqRi3A8Kv3Zjkuq51mgvJ2%2Fty95h3Mmb7fBAjYf1O5qfxFHMOwTHnd%2B405w4Sbi9hz3vxwR7WA6I%2BaBnbSmM%2FV9JtooNho%3D"}],"max_age":604800}'
+      Nel:
+      - '{"max_age":604800,"report_to":"cf-nel"}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 624528230e644e68-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12450000#CGD2TFVZKAXHJ3JPB5JYBCR2BAEX4BX6IOLJ4MP7VZWHNXNY2NXQ","last-round":12456409,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12456410,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":615634115}
+
+'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 03:31:48 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Sign_OreIdController/GET_/new/with_transfer/creates_a_correct_BlockchainTransaction.yml
+++ b/spec/vcr/Sign_OreIdController/GET_/new/with_transfer/creates_a_correct_BlockchainTransaction.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 03:31:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x93f836"}'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 03:31:44 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Sign_OreIdController/GET_/new/with_transfer/populates_source.yml
+++ b/spec/vcr/Sign_OreIdController/GET_/new/with_transfer/populates_source.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 03:31:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x93f836"}'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 03:31:45 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Sign_OreIdController/GET_/new/with_transfer/redirects_to_sign_url.yml
+++ b/spec/vcr/Sign_OreIdController/GET_/new/with_transfer/redirects_to_sign_url.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 03:31:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x93f836"}'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 03:31:46 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Sign_OreIdController/GET_/new/with_transfer_rule/creates_a_correct_BlockchainTransaction.yml
+++ b/spec/vcr/Sign_OreIdController/GET_/new/with_transfer_rule/creates_a_correct_BlockchainTransaction.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.testnet.algoexplorer.io/v2/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 20 Feb 2021 03:34:10 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d9eebdbea074a93d680b9f77e32927e121613792050; expires=Mon, 22-Mar-21
+        03:34:10 GMT; path=/; domain=.algoexplorer.io; HttpOnly; SameSite=Lax
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Disable-Tracking, X-Algoexplorer-Api-Key, X-Debug-Stats, Authorization
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, private
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085f19943e00004dbeb504b000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=ThPuzVeo8kP4bazCfSsE8BoaIrGGVJ5QR6R8osxu9ik2jNefuItIYmSgD4jochCriJAQKsV0NFaQkvI1ZrgUHNLvN8FtTGVqTm9qJMvUDCxealKGR2YAdC6gEt4%3D"}]}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 62452b99fde64dbe-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"catchpoint":"","catchpoint-acquired-blocks":0,"catchpoint-processed-accounts":0,"catchpoint-total-accounts":0,"catchpoint-total-blocks":0,"catchpoint-verified-accounts":0,"catchup-time":0,"last-catchpoint":"12450000#CGD2TFVZKAXHJ3JPB5JYBCR2BAEX4BX6IOLJ4MP7VZWHNXNY2NXQ","last-round":12456442,"last-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version":"https://github.com/algorandfoundation/specs/tree/3a83c4c743f8b17adfd73944b4319c25722a6782","next-version-round":12456443,"next-version-supported":true,"stopped-at-unsupported-round":false,"time-since-last-round":2868259761}
+
+'
+    http_version: null
+  recorded_at: Sat, 20 Feb 2021 03:34:10 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
- Update transfer rules, freeze, and accounts UI to support Algorand Security Token via OreID
- Fix datetime input for transfer rules and account records
- Refactor stimulus controller for accounts
- Store AccountTokenRecord wallet address in BlockchainTransaction
destination
- Fix appArgs integer encoding incompatabilities with AlgoIndexer (allow
up to 64 bit uints)
- Validate presence of address for ore_id wallets only if wallet
    provisions are present
- Fix reschedule logic for wallet provision jobs
- Add `TokenType#default_reg_group` method to security tokens
- Add `TokenType#transfer_rule_sync_job` method to security tokens
- Add `TokenType#accounts_sync_job` method to security tokens
- Implement jobs to sync AlgorandSecurityToken transfer rules and accounts with blockchain
- Add `Refreshable` concern to calculate whether the scope should be synced with blockchain at the moment
- Add Refresh button to Accounts UI for AlgorandSecurityToken

Resolves:
https://www.pivotaltracker.com/story/show/175049220
https://www.pivotaltracker.com/story/show/176909035
https://www.pivotaltracker.com/story/show/176909053
https://www.pivotaltracker.com/story/show/177045614
https://www.pivotaltracker.com/story/show/176990770
https://www.pivotaltracker.com/story/show/177050780

Known issues with transfer rules UI:
- Freeze button doesn’t display tx progress (staying in old state until tx is succeed)
- Failed transfer rules creation stays in pending state until new transfer rule with the same groups is created
- Deletion of a transfer rule doesn’t display tx progress properly (backend creates a new rule to perform the “delete”, so the rule is staying in the old state, and new rule appears in pending state until it’s confirmed, after that both rules are removed)