### PR TITLE
OreIdAccount#sync_password_update: Add early exit if wrong state

### DIFF
--- a/app/models/ore_id_account.rb
+++ b/app/models/ore_id_account.rb
@@ -88,6 +88,8 @@ class OreIdAccount < ApplicationRecord
   end
 
   def sync_password_update
+    return unless unclaimed?
+
     if service.password_updated?
       ok!
     else

--- a/spec/jobs/ore_id_password_update_sync_job_spec.rb
+++ b/spec/jobs/ore_id_password_update_sync_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe OreIdPasswordUpdateSyncJob, type: :job do
-  subject { create(:ore_id, skip_jobs: true) }
+  subject { create(:ore_id, skip_jobs: true, state: 'unclaimed') }
 
   context 'when sync is allowed' do
     before { allow_any_instance_of(subject.class).to receive(:sync_allowed?).and_return(true) }

--- a/spec/models/ore_id_account_spec.rb
+++ b/spec/models/ore_id_account_spec.rb
@@ -115,14 +115,25 @@ RSpec.describe OreIdAccount, type: :model do
   end
 
   describe '#sync_password_update' do
+    before do
+      allow_any_instance_of(OreIdService).to receive(:password_updated?).and_return(true)
+    end
+
     context 'when remote password has been updated' do
-      before do
-        allow_any_instance_of(OreIdService).to receive(:password_updated?).and_return(true)
-      end
+      subject { create(:ore_id, state: 'unclaimed') }
 
       specify do
         expect(subject).to receive(:ok!)
         subject.sync_password_update
+      end
+    end
+
+    context 'when Ore Id Account has wrong state' do
+      subject { create(:ore_id, state: 'ok') }
+
+      specify do
+        expect(subject).not_to receive(:ok!)
+        expect(subject.sync_password_update).to be nil
       end
     end
   end


### PR DESCRIPTION
task: https://www.pivotaltracker.com/story/show/177032675

This PR allows to successfully exit on `OreIdAccount#sync_password_update` to not to reschedule the job.