### PR TITLE
Update BlockchainTransactions API controller

### DIFF
--- a/app/javascript/controllers/account-form_controller.js
+++ b/app/javascript/controllers/account-form_controller.js
@@ -31,7 +31,7 @@ export default class extends ComakerySecurityTokenController {
       if (response.status === 201) {
         response.json().then(r => {
           this.data.set('id', r.id)
-          this.data.set('type', 'AccountTokenRecord')
+          this.data.set('type', 'account_token_records')
           this._createTransaction('setAddressPermissions')
         })
       } else {

--- a/app/javascript/controllers/transfer-rule-form_controller.js
+++ b/app/javascript/controllers/transfer-rule-form_controller.js
@@ -38,7 +38,7 @@ export default class extends ComakerySecurityTokenController {
     }).then(response => {
       if (response.status === 201) {
         response.json().then(r => {
-          this.data.set('type', 'TransferRule')
+          this.data.set('type', 'transfer_rules')
           this.data.set('id', r.id)
           this._createTransaction('setAllowGroupTransfer')
         })

--- a/app/models/concerns/synchronisable.rb
+++ b/app/models/concerns/synchronisable.rb
@@ -46,17 +46,23 @@ module Synchronisable
       return Time.current unless latest_synchronisation
       return max_seconds_in_pending.seconds.from_now if sync_in_progress?
       return latest_synchronisation.updated_at + timeout if latest_synchronisation.ok?
-      return latest_synchronisation.updated_at + timeout(scale) if latest_synchronisation.failed?
+      return latest_synchronisation.updated_at + timeout(scale: scale) if latest_synchronisation.failed?
     end
 
-    def timeout(scale = nil)
-      case scale
-      when :exponential
-        min_seconds_between_syncs**failed_transactions_row
-      when :linear
-        min_seconds_between_syncs * failed_transactions_row
+    def timeout(scale: nil)
+      t = case scale
+          when :exponential
+            min_seconds_between_syncs**failed_transactions_row
+          when :linear
+            min_seconds_between_syncs * failed_transactions_row
+          else
+            min_seconds_between_syncs
+      end
+
+      if t > 1.month
+        1.month.to_i
       else
-        min_seconds_between_syncs
+        t
       end
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,6 +22,7 @@ class Project < ApplicationRecord
   has_many :interests # rubocop:todo Rails/HasManyOrHasOneDependent
   has_many :interested, -> { distinct }, through: :interests, source: :account
   has_many :account_token_records, ->(project) { where token_id: project.token_id }, through: :interested, source: :account_token_records
+  has_many :transfer_rules, through: :token
 
   has_many :transfer_types, dependent: :destroy
   has_many :award_types, inverse_of: :project, dependent: :destroy

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -78,6 +78,14 @@ class Token < ApplicationRecord
     self
   end
 
+  def blockchain_transaction_class
+    if token_frozen?
+      'BlockchainTransactionTokenUnfreeze'
+    else
+      'BlockchainTransactionTokenFreeze'
+    end.constantize
+  end
+
   def token_type
     if _token_type
       @token_type ||= "TokenType::#{_token_type.camelize}".constantize.new(

--- a/spec/acceptance/api/v1/17_blockchain_transactions_spec.rb
+++ b/spec/acceptance/api/v1/17_blockchain_transactions_spec.rb
@@ -45,8 +45,8 @@ resource 'VII. Blockchain Transactions' do
     end
 
     with_options with_example: true do
-      parameter :blockchain_transactable_id, 'transactable id to generate transaction for', required: false, type: :string
-      parameter :blockchain_transactable_type, 'transactable type to generate transaction for – Award (Default), TransferRule, AccountTokenRecord', required: false, type: :string
+      parameter :blockchain_transactable_type, 'transactable type to generate transaction for (awards, transfer_rules, account_token_records)', required: false, type: :string
+      parameter :blockchain_transactable_id, 'transactable id of transactable type to generate transaction for', required: false, type: :string
     end
 
     context '201' do
@@ -89,10 +89,11 @@ resource 'VII. Blockchain Transactions' do
         expect(status).to eq(201)
       end
 
-      example 'GENERATE TRANSACTION – TRANSACTABLE ID' do
-        explanation 'Generates a new blockchain transaction for transactable with supplied id and locks the transactable for 10 minutes'
+      example 'GENERATE TRANSACTION – TRANSACTABLE TYPE' do
+        explanation 'Generates a new blockchain transaction for transactable with supplied type and locks the transactable for 10 minutes'
+        create(:transfer_rule, token: project.token)
 
-        request = build(:api_signed_request, { transaction: transaction, blockchain_transactable_id: award.id }, api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST', 'example.org')
+        request = build(:api_signed_request, { transaction: transaction, blockchain_transactable_type: 'transfer_rules' }, api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST', 'example.org')
 
         VCR.use_cassette("infura/#{project.token._blockchain}/#{project.token.contract_address}/contract_init") do
           do_request(request)
@@ -101,10 +102,11 @@ resource 'VII. Blockchain Transactions' do
         expect(status).to eq(201)
       end
 
-      example 'GENERATE TRANSACTION – TRANSACTABLE TYPE' do
-        explanation 'Generates a new blockchain transaction for transactable with supplied type and locks the transactable for 10 minutes'
+      example 'GENERATE TRANSACTION – TRANSACTABLE TYPE AND TRANSACTABLE ID' do
+        explanation 'Generates a new blockchain transaction for transactable with supplied type and id and locks the transactable for 10 minutes'
+        t = create(:transfer_rule, token: project.token)
 
-        request = build(:api_signed_request, { transaction: transaction, blockchain_transactable_type: create(:transfer_rule, token: project.token) && 'TransferRule' }, api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST', 'example.org')
+        request = build(:api_signed_request, { transaction: transaction, blockchain_transactable_type: 'transfer_rules', blockchain_transactable_id: t.id }, api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST', 'example.org')
 
         VCR.use_cassette("infura/#{project.token._blockchain}/#{project.token.contract_address}/contract_init") do
           do_request(request)

--- a/spec/controllers/api/v1/blockchain_transactions_controller_spec.rb
+++ b/spec/controllers/api/v1/blockchain_transactions_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::BlockchainTransactionsController, type: :controller do
   end
 
   describe 'POST #create', vcr: true do
-    context 'with transfers available for transaction' do
+    context 'with awards available for transaction' do
       let!(:award) { create(:award, status: :accepted, award_type: create(:award_type, project: project)) }
       let!(:wallet) { create(:wallet, account: award.account, _blockchain: project.token._blockchain, address: build(:ethereum_address_1)) }
 
@@ -40,6 +40,31 @@ RSpec.describe Api::V1::BlockchainTransactionsController, type: :controller do
         expect do
           post :create, params: params
         end.to change(project.blockchain_transactions, :count).by(1)
+
+        expect(project.blockchain_transactions.last).to be_a(BlockchainTransactionAward)
+      end
+
+      it 'returns a success response' do
+        params = build(:api_signed_request, valid_create_attributes, api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
+        params[:project_id] = project.id
+
+        post :create, params: params
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'with account_token_records available for transaction' do
+      let!(:account_token_record) { create(:account_token_record, account: project.account, token: project.token) }
+
+      it 'creates a new BlockchainTransaction' do
+        params = build(:api_signed_request, valid_create_attributes, api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
+        params[:project_id] = project.id
+
+        expect do
+          post :create, params: params
+        end.to change(project.blockchain_transactions, :count).by(1)
+
+        expect(project.blockchain_transactions.last).to be_a(BlockchainTransactionAccountTokenRecord)
       end
 
       it 'returns a success response' do
@@ -75,56 +100,67 @@ RSpec.describe Api::V1::BlockchainTransactionsController, type: :controller do
       end
     end
 
-    context 'with supplied custom blockchain_transactable_type' do
+    context 'with custom blockchain_transactable_type' do
       let!(:transfer_rule) { create(:transfer_rule, token: project.token) }
 
       it 'creates a new BlockchainTransaction for the blockchain_transactable_type' do
-        params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_type: 'TransferRule'), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
+        params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_type: 'transfer_rules'), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
         params[:project_id] = project.id
 
         expect do
           post :create, params: params
         end.to change(project.blockchain_transactions, :count).by(1)
+
+        expect(project.blockchain_transactions.last).to be_a(BlockchainTransactionTransferRule)
       end
 
       it 'returns a success response' do
-        params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_type: 'TransferRule'), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
+        params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_type: 'transfer_rules'), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
         params[:project_id] = project.id
 
         post :create, params: params
         expect(response).to have_http_status(:created)
       end
-    end
 
-    context 'with supplied valid blockchain_transactable_id' do
-      let!(:award) { create(:award, status: :accepted, award_type: create(:award_type, project: project)) }
-      let!(:wallet) { create(:wallet, account: award.account, _blockchain: project.token._blockchain, address: build(:ethereum_address_1)) }
+      context 'and valid custom blockchain_transactable_id' do
+        subject do
+          params = build(
+            :api_signed_request,
+            valid_create_attributes.merge(
+              blockchain_transactable_type: 'transfer_rules',
+              blockchain_transactable_id: transfer_rule.id
+            ),
+            api_v1_project_blockchain_transactions_path(
+              project_id: project.id
+            ),
+            'POST'
+          )
+          params[:project_id] = project.id
 
-      it 'creates a new BlockchainTransaction for the blockchain_transactable_id' do
-        params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_id: award.id), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
-        params[:project_id] = project.id
-
-        expect do
           post :create, params: params
-        end.to change(project.blockchain_transactions, :count).by(1)
+        end
+
+        it 'creates a new BlockchainTransaction for the blockchain_transactable_id' do
+          expect { subject }.to change(project.blockchain_transactions, :count).by(1)
+
+          expect(project.blockchain_transactions.last).to be_a(BlockchainTransactionTransferRule)
+          expect(project.blockchain_transactions.last.blockchain_transactable).to eq(transfer_rule)
+        end
+
+        it 'returns a success response' do
+          subject
+          expect(response).to have_http_status(:created)
+        end
       end
 
-      it 'returns a success response' do
-        params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_id: award.id), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
-        params[:project_id] = project.id
+      context 'and invalid custom blockchain_transactable_id' do
+        it 'returns an error' do
+          params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_id: 0), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
+          params[:project_id] = project.id
 
-        post :create, params: params
-        expect(response).to have_http_status(:created)
-      end
-    end
-
-    context 'with supplied invalid blockchain_transactable_id' do
-      it 'returns an error' do
-        params = build(:api_signed_request, valid_create_attributes.merge(blockchain_transactable_id: 0), api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
-        params[:project_id] = project.id
-
-        post :create, params: params
-        expect(response).to have_http_status(:no_content)
+          post :create, params: params
+          expect(response).to have_http_status(:no_content)
+        end
       end
     end
   end

--- a/spec/models/concerns/blockchain_transactable_spec.rb
+++ b/spec/models/concerns/blockchain_transactable_spec.rb
@@ -14,13 +14,27 @@ shared_examples 'blockchain_transactable' do
 
   describe 'blockchain_transaction_class' do
     subject { described_class.new.blockchain_transaction_class }
+    let(:classname) do
+      if described_class == Token
+        'BlockchainTransactionTokenFreeze'
+      else
+        "BlockchainTransaction#{described_class}"
+      end
+    end
 
-    it { is_expected.to eq("BlockchainTransaction#{described_class}".constantize) }
+    it { is_expected.to eq(classname.constantize) }
   end
 
   describe 'new_blockchain_transaction' do
     subject { described_class.new.new_blockchain_transaction({}) }
+    let(:classname) do
+      if described_class == Token
+        'BlockchainTransactionTokenFreeze'
+      else
+        "BlockchainTransaction#{described_class}"
+      end
+    end
 
-    it { is_expected.to be_a("BlockchainTransaction#{described_class}".constantize) }
+    it { is_expected.to be_a(classname.constantize) }
   end
 end

--- a/spec/models/concerns/blockchain_transactable_spec.rb
+++ b/spec/models/concerns/blockchain_transactable_spec.rb
@@ -11,4 +11,16 @@ shared_examples 'blockchain_transactable' do
       expect(account_token_record.latest_blockchain_transaction).to be_nil
     end
   end
+
+  describe 'blockchain_transaction_class' do
+    subject { described_class.new.blockchain_transaction_class }
+
+    it { is_expected.to eq("BlockchainTransaction#{described_class}".constantize) }
+  end
+
+  describe 'new_blockchain_transaction' do
+    subject { described_class.new.new_blockchain_transaction({}) }
+
+    it { is_expected.to be_a("BlockchainTransaction#{described_class}".constantize) }
+  end
 end

--- a/spec/models/concerns/synchronisable_spec.rb
+++ b/spec/models/concerns/synchronisable_spec.rb
@@ -96,4 +96,38 @@ shared_examples 'synchronisable' do
       specify { expect(subject.next_sync_allowed_after).to eq(subject.latest_synchronisation.updated_at + subject.min_seconds_between_syncs**2) }
     end
   end
+
+  describe '#timeout' do
+    let(:failed_transactions_row) { 2 }
+
+    before do
+      allow(subject).to receive(:failed_transactions_row).and_return(failed_transactions_row)
+    end
+
+    context 'with exponential scale' do
+      specify do
+        expect(subject.timeout(scale: :exponential)).to eq(subject.min_seconds_between_syncs**failed_transactions_row)
+      end
+    end
+
+    context 'with linear scale' do
+      specify do
+        expect(subject.timeout(scale: :linear)).to eq(subject.min_seconds_between_syncs * failed_transactions_row)
+      end
+    end
+
+    context 'without scale' do
+      specify do
+        expect(subject.timeout).to eq(subject.min_seconds_between_syncs)
+      end
+    end
+
+    context 'with a value over a month' do
+      let(:failed_transactions_row) { 55356 }
+
+      specify do
+        expect(subject.timeout(scale: :exponential)).to eq(1.month.to_i)
+      end
+    end
+  end
 end

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_account_token_records_available_for_transaction/creates_a_new_BlockchainTransaction.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_account_token_records_available_for_transaction/creates_a_new_BlockchainTransaction.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:29:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951b53"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:29:55 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:29:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:29:56 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_account_token_records_available_for_transaction/returns_a_success_response.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_account_token_records_available_for_transaction/returns_a_success_response.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:40:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951b7e"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:40:20 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:40:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:40:21 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_awards_available_for_transaction/creates_a_new_BlockchainTransaction.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_awards_available_for_transaction/creates_a_new_BlockchainTransaction.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 01:52:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951acb"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 01:52:28 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 01:52:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 01:52:29 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_awards_available_for_transaction/returns_a_success_response.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_awards_available_for_transaction/returns_a_success_response.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 01:52:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951acb"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 01:52:30 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 01:52:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 01:52:30 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/and_valid_custom_blockchain_transactable_id/creates_a_new_BlockchainTransaction_for_the_blockchain_transactable_id.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/and_valid_custom_blockchain_transactable_id/creates_a_new_BlockchainTransaction_for_the_blockchain_transactable_id.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951b83"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:19 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:19 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/and_valid_custom_blockchain_transactable_id/returns_a_success_response.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/and_valid_custom_blockchain_transactable_id/returns_a_success_response.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951b83"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:20 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:21 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/creates_a_new_BlockchainTransaction_for_the_blockchain_transactable_type.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/creates_a_new_BlockchainTransaction_for_the_blockchain_transactable_type.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951b82"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:15 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:16 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/returns_a_success_response.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_custom_blockchain_transactable_type/returns_a_success_response.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x951b82"}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:17 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Mar 2021 02:42:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Thu, 04 Mar 2021 02:42:17 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
- Generate transactions for AccountTokenRecords and Awards by default
- Accept custom transactable id only together with custom transactable
type
- Fix a bug in ready_for_blockchain_transaction scope which might not
return a transactable if another transactable with the same database id
(but different type) has blockchain transactions
- Add new_blockchain_transaction helper to blockchain_transactable
concern
- Limit rescheduling time to 1 month

Resolves:
https://www.pivotaltracker.com/story/show/177152726
https://www.pivotaltracker.com/story/show/177214184