### PR TITLE
Filter `synced` AccounTokenRecords and TransferRules from `.ready_for_blockchain_transaction`

### DIFF
--- a/app/models/account_token_record.rb
+++ b/app/models/account_token_record.rb
@@ -24,6 +24,7 @@ class AccountTokenRecord < ApplicationRecord
   validates :max_balance, inclusion: { in: BALANCE_MIN..BALANCE_MAX }, allow_nil: true
 
   enum status: { created: 0, pending: 1, synced: 2, failed: 3 }
+  scope :not_synced, -> { where.not(status: :synced) }
 
   delegate :_blockchain, :blockchain, to: :token
 

--- a/app/models/transfer_rule.rb
+++ b/app/models/transfer_rule.rb
@@ -19,6 +19,7 @@ class TransferRule < ApplicationRecord
   validate :groups_belong_to_same_token
 
   enum status: { created: 0, pending: 1, synced: 2, failed: 3 }
+  scope :not_synced, -> { where.not(status: :synced) }
 
   def lockup_until
     super && Time.zone.at(super)

--- a/spec/models/account_token_record_spec.rb
+++ b/spec/models/account_token_record_spec.rb
@@ -108,7 +108,13 @@ describe AccountTokenRecord do
       expect(described_class.ready_for_blockchain_transaction).to include(blockchain_transaction.blockchain_transactable)
     end
 
-    it 'doesnt return account_token_records with lates blockchain_transaction Created less than 10 minutes ago' do
+    it 'doesnt return synced account_token_records without blockchain_transaction' do
+      account_token_record.synced!
+
+      expect(described_class.ready_for_blockchain_transaction).not_to include(account_token_record)
+    end
+
+    it 'doesnt return account_token_records with latest blockchain_transaction Created less than 10 minutes ago' do
       create(:blockchain_transaction_account_token_record, blockchain_transactable: blockchain_transaction.blockchain_transactable, created_at: 1.second.ago)
 
       expect(described_class.ready_for_blockchain_transaction).not_to include(blockchain_transaction.blockchain_transactable)

--- a/spec/models/transfer_rule_spec.rb
+++ b/spec/models/transfer_rule_spec.rb
@@ -118,7 +118,13 @@ describe TransferRule do
       expect(described_class.ready_for_blockchain_transaction).to include(blockchain_transaction.blockchain_transactable)
     end
 
-    it 'doesnt return transfer_rules with lates blockchain_transaction Created less than 10 minutes ago' do
+    it 'doesnt return synced transfer_rules without blockchain_transaction' do
+      transfer_rule.synced!
+
+      expect(described_class.ready_for_blockchain_transaction).not_to include(transfer_rule)
+    end
+
+    it 'doesnt return transfer_rules with latest blockchain_transaction Created less than 10 minutes ago' do
       create(:blockchain_transaction_transfer_rule, blockchain_transactable: blockchain_transaction.blockchain_transactable, created_at: 1.second.ago)
 
       expect(described_class.ready_for_blockchain_transaction).not_to include(blockchain_transaction.blockchain_transactable)


### PR DESCRIPTION
Do not create transactions for records synced directly from blockchain without a tx associated.
 
Resolves:
https://www.pivotaltracker.com/story/show/177228983