### PR TITLE
Bugfixes for OreId wallets

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -29,7 +29,9 @@ class Wallet < ApplicationRecord
 
   def available_blockchains
     available_blockchains = Blockchain.available
-    available_blockchains.reject!(&:supported_by_ore_id?)
+
+    # TODO: Add Blockchain flag to indicate availability, regardless ore_id support
+    available_blockchains.reject! { |b| b.is_a? Blockchain::Algorand }
     available_blockchains.map(&:key)
   end
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -13,7 +13,7 @@ class Wallet < ApplicationRecord
   validates :source, presence: true
   validates :address, presence: true, unless: :empty_address_allowed?
   validates :address, blockchain_address: true
-  validates :address, uniqueness: { scope: %i[account_id _blockchain], message: 'has already been taken for the blockchain' }
+  validates :address, uniqueness: { scope: %i[account_id _blockchain], allow_nil: true, message: 'has already been taken for the blockchain' }
   validates :_blockchain, uniqueness: { scope: %i[account_id primary_wallet], message: 'has primary wallet already' }, if: :primary_wallet?
   validates :name, presence: true
   validates :project_id, presence: true, if: :hot_wallet?

--- a/app/services/wallet_creator.rb
+++ b/app/services/wallet_creator.rb
@@ -15,6 +15,11 @@ class WalletCreator
 
       wallet = account.wallets.new(wallet_attrs)
 
+      if wallet.errors.any?
+        errors[i] = wallet.errors
+        next
+      end
+
       provision = Provision.new(wallet, tokens_to_provision)
 
       if provision.should_be_provisioned?

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -93,17 +93,18 @@ describe Wallet, type: :model do
       allow(Blockchain).to receive(:testnets_available?).and_return(true)
 
       expect(subject.available_blockchains).to include('bitcoin_test')
+      expect(subject.available_blockchains).to include('ethereum')
     end
 
     it 'doesnt return testnets if TESTNETS_AVAILABLE set to false' do
       allow(Blockchain).to receive(:testnets_available?).and_return(false)
 
       expect(subject.available_blockchains).not_to include('bitcoin_test')
+      expect(subject.available_blockchains).not_to include('ethereum_ropsten')
     end
 
     it 'doesnt include blockchains with supported_by_ore_id flag' do
       expect(subject.available_blockchains).not_to include('algorand')
-      expect(subject.available_blockchains).not_to include('ethereum')
     end
   end
 

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -11,7 +11,7 @@ describe Wallet, type: :model do
   it { is_expected.to have_many(:awards).with_foreign_key(:recipient_wallet_id).dependent(:nullify) }
   it { is_expected.to have_many(:balances).dependent(:destroy) }
   it { is_expected.to validate_presence_of(:address) }
-  it { is_expected.to validate_uniqueness_of(:_blockchain).scoped_to(:account_id, :primary_wallet).with_message('has primary wallet already').ignoring_case_sensitivity }
+  it { is_expected.to validate_uniqueness_of(:_blockchain).scoped_to(:account_id, :primary_wallet).with_message('has primary wallet already').ignoring_case_sensitivity.allow_nil }
   it { is_expected.to have_readonly_attribute(:_blockchain) }
   it { is_expected.to define_enum_for(:source).with_values({ user_provided: 0, ore_id: 1, hot_wallet: 2 }) }
   it { is_expected.not_to validate_presence_of(:ore_id_account) }

--- a/spec/services/wallet_creator_spec.rb
+++ b/spec/services/wallet_creator_spec.rb
@@ -123,5 +123,12 @@ RSpec.describe WalletCreator do
       let(:tokens_to_provision) { [{ token_id: asa_token.id.to_s }] }
       it { expect(wallets[0].errors.messages).to eq(tokens_to_provision: ["Some tokens can't be provisioned: [#{asa_token.id}]"]) }
     end
+
+    context 'wallet is invalid' do
+      let(:asa_token) { create(:asa_token) }
+      let(:wallets_params) { [{ blockchain: :bitcoin, address: '', tokens_to_provision: tokens_to_provision, name: 'Wallet 1' }] }
+      let(:tokens_to_provision) { [] }
+      it { expect(wallets[0].errors.messages).to eq(address: ["can't be blank"]) }
+    end
   end
 end


### PR DESCRIPTION
1) Only exclude Algorand wallets from manual managing on Wallets page.
This is critical to keep Metamask integration working.
2) Allow nil address for Wallet in uniqueness validation
3) Fix WalletCreator to return any wallet-level errors when there are no tokens to provision (https://www.pivotaltracker.com/story/show/177423995)