### PR TITLE
Fix transfer's order in case of set priority

### DIFF
--- a/app/models/concerns/blockchain_transactable.rb
+++ b/app/models/concerns/blockchain_transactable.rb
@@ -40,7 +40,7 @@ module BlockchainTransactable
           )
       q = q.accepted if table_name == 'awards'
       q = q.not_synced if table_name.in? %w[account_token_records transfer_rules]
-      q = q.order("#{table_name}.prioritized_at DESC, #{table_name}.created_at ASC") if table_name.in? %w[account_token_records awards]
+      q = q.order("#{table_name}.prioritized_at DESC nulls last, #{table_name}.created_at ASC") if table_name.in? %w[account_token_records awards]
       q
     }
 

--- a/spec/controllers/api/v1/blockchain_transactions_controller_spec.rb
+++ b/spec/controllers/api/v1/blockchain_transactions_controller_spec.rb
@@ -111,6 +111,21 @@ RSpec.describe Api::V1::BlockchainTransactionsController, type: :controller do
           end
         end
 
+        context 'with registered hw and hot_wallet_mode is auto_sending with prioritized transfer' do
+          let!(:prioritized_award) { create(:award, prioritized_at: Time.zone.now, account: award.account, status: :accepted, award_type: create(:award_type, project: project)) }
+          let(:hot_wallet) { build(:wallet, account: nil, source: :hot_wallet, _blockchain: project.token._blockchain, address: build(:ethereum_address_1)) }
+          let(:hot_wallet_mode) { 'auto_sending' }
+
+          it 'creates the prioritized transaction' do
+            params = build(:api_signed_request, valid_create_attributes, api_v1_project_blockchain_transactions_path(project_id: project.id), 'POST')
+            params[:project_id] = project.id
+
+            post :create, params: params
+            expect(response).to have_http_status(:created)
+            expect(BlockchainTransactionAward.last.blockchain_transactable).to eq prioritized_award
+          end
+        end
+
         context 'with NOT registered hw and hot_wallet_mode is disabled' do
           let(:hot_wallet) { nil }
           let(:hot_wallet_mode) { 'disabled' }

--- a/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_awards_available_for_transaction/with_request_from_a_hot_wallet/with_registered_hw_and_hot_wallet_mode_is_auto_sending_with_prioritized_transfer/creates_the_prioritized_transaction.yml
+++ b/spec/vcr/Api_V1_BlockchainTransactionsController/POST_create/with_awards_available_for_transaction/with_request_from_a_hot_wallet/with_registered_hw_and_hot_wallet_mode_is_auto_sending_with_prioritized_transfer/creates_the_prioritized_transaction.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Mar 2021 08:58:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":"0x9711ae"}'
+    http_version: null
+  recorded_at: Wed, 24 Mar 2021 08:58:40 GMT
+- request:
+    method: post
+    uri: https://ropsten.infura.io/v3/39f6ad316c5a4b87a0f90956333c3666
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ropsten.infura.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Mar 2021 08:58:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"jsonrpc":"2.0","id":1,"result":[]}'
+    http_version: null
+  recorded_at: Wed, 24 Mar 2021 08:58:40 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
bugfix for the task: https://www.pivotaltracker.com/story/show/177083180

The problem was with nulls records which were on top of the order in case of `DESC`. Fixed with `prioritized_at DESC nulls last`