### PR TITLE
Bump mimemagic gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -839,4 +839,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.2.3
+   2.2.4


### PR DESCRIPTION
This PR fixes `bundle install`

There is crazy issue with `mimemagic` gem related to licencing. They removed some versions of the gem and now it requires update the gem version 🤯
It broke all rails installations because `mimemagic` is required for `activestorage`

Details: https://github.com/rails/rails/issues/41750