### PR TITLE
Update recovery service url

### DIFF
--- a/app/models/ore_id_service.rb
+++ b/app/models/ore_id_service.rb
@@ -87,7 +87,7 @@ class OreIdService
       self.class.post(
         '/app-token',
         headers: request_headers,
-        body: create_token_params(recovery_token).to_json
+        body: recovery_token ? create_token_params(recovery_token).to_json : nil
       )
     )
 
@@ -113,10 +113,12 @@ class OreIdService
       callback_url: callback_url,
       background_color: 'FFFFFF',
       state: state,
-      email: remote['email']
+      recover_action: :republic,
+      email: remote['email'],
+      account: ore_id.account_name
     }
 
-    append_hmac_to_url "https://service.oreid.io/reset-password?#{params.to_query}"
+    append_hmac_to_url "https://service.oreid.io/recover-account?#{params.to_query}"
   end
 
   def sign_url(transaction:, callback_url:, state:)

--- a/spec/controllers/api/v1/wallets_controller_spec.rb
+++ b/spec/controllers/api/v1/wallets_controller_spec.rb
@@ -244,13 +244,15 @@ RSpec.describe Api::V1::WalletsController, type: :controller do
         parsed_reset_url = URI.parse(parsed_response['reset_url'])
 
         expect(parsed_reset_url.host).to eq 'service.oreid.io'
-        expect(parsed_reset_url.path).to eq '/reset-password'
+        expect(parsed_reset_url.path).to eq '/recover-account'
         expect(Rack::Utils.parse_nested_query(parsed_reset_url.query)).to eq(
+          'account' => '',
           'app_access_token' => 'dummy_token',
           'background_color' => 'FFFFFF',
           'callback_url' => 'https://localhost',
           'email' => 'dummyemail',
           'provider' => 'email',
+          'recover_action' => 'republic',
           'state' => '',
           'hmac' => build(:ore_id_hmac, parsed_response['reset_url'], url_encode: false)
         )

--- a/spec/models/ore_id_service_spec.rb
+++ b/spec/models/ore_id_service_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
     end
 
     specify do
-      url = 'https://service.oreid.io/reset-password?app_access_token=test&background_color=FFFFFF&callback_url=localhost&email=dummyemail&provider=email&state=dummystate'
+      url = 'https://service.oreid.io/recover-account?account=ore1ryuzfqwy&app_access_token=test&background_color=FFFFFF&callback_url=localhost&email=dummyemail&provider=email&recover_action=republic&state=dummystate'
       hmac = build(:ore_id_hmac, url)
       expect(subject.reset_url('localhost', 'dummystate', 'dummmyrecovery')).to eq("#{url}&hmac=#{hmac}")
     end

--- a/spec/vcr/ore_id_service/token.yml
+++ b/spec/vcr/ore_id_service/token.yml
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Nov 2020 14:17:48 GMT
+      - Thu, 01 Apr 2021 17:12:26 GMT
       Content-Type:
       - application/json; charset=utf-8
       Vary:
@@ -35,14 +35,14 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Etag:
-      - W/"54-Yr2fnDLyk84iS5jmSaVBa+V2fm4"
+      - W/"54-GKRmoGTtBzLiCucGgag+3HHaEwk"
       Via:
       - 1.1 google
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"processId":"032913784919","appAccessToken":"809c8807-be0f-4f5c-82ac-0b0898755e12"}'
+      string: '{"processId":"d015c86bdced","appAccessToken":"dbf4849a-6e23-470f-b74e-8a9f6ac64343"}'
     http_version: null
-  recorded_at: Wed, 04 Nov 2020 14:17:48 GMT
+  recorded_at: Thu, 01 Apr 2021 17:12:26 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
- Use `/recover-account` instead of `/reset-password`
- Fix app-token for non-recovery requests