### PR TITLE
Fast webpack-dev-server instead of asset compile

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -138,8 +138,8 @@ jobs:
         path: public/packs
         key: ${{ runner.os }}-${{ matrix.ruby }}-packs-
 
-    - name: Precompile assets
-      run: env bundle exec rails assets:precompile
+    - name: Run dev asset server
+      run: nohup env bin/webpack-dev-server &
 
     - name: Setup database
       run: env bundle exec rails db:create


### PR DESCRIPTION
Switch from precompiling assets to using the bin/webpack-dev-server