### PR TITLE
logo URL fix

### DIFF
--- a/app/decorators/token_decorator.rb
+++ b/app/decorators/token_decorator.rb
@@ -23,11 +23,7 @@ class TokenDecorator < Draper::Decorator
     _blockchain
   end
 
-  def logo_url(size = 100)
-    GetImageVariantPath.call(
-      attachment: logo_image,
-      resize_to_fill: [size, size],
-      fallback: helpers.image_url('default_project.jpg')
-    ).path
+  def logo_url
+    Rails.application.routes.url_helpers.url_for(logo_image)
   end
 end

--- a/app/decorators/token_decorator.rb
+++ b/app/decorators/token_decorator.rb
@@ -23,7 +23,7 @@ class TokenDecorator < Draper::Decorator
     _blockchain
   end
 
-  def logo_url
-    Rails.application.routes.url_helpers.url_for(logo_image)
+  def logo_url(host: Rails.application.routes.default_url_options[:host])
+    Rails.application.routes.url_helpers.polymorphic_url(logo_image, host: host)
   end
 end

--- a/app/views/api/v1/tokens/_token.json.jbuilder
+++ b/app/views/api/v1/tokens/_token.json.jbuilder
@@ -6,7 +6,8 @@ json.call(
   :network,
   :contract_address,
   :decimal_places,
-  :logo_url,
   :created_at,
   :updated_at
 )
+
+json.logo_url token.decorate.logo_url(host: @whitelabel_mission&.whitelabel_domain)

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe Api::V1::TokensController, type: :controller do
   end
 
   describe 'GET #index' do
+    context 'with rendered views' do
+      render_views
+
+      it 'uses whitelabel domain for token logo_url' do
+        params = build(:api_signed_request, '', api_v1_tokens_path, 'GET')
+        params[:format] = :json
+
+        get :index, params: params
+        expect(response).to be_successful
+        expect(JSON.parse(response.body).first.dig('logo_url')).to include(active_whitelabel_mission.whitelabel_domain)
+      end
+    end
+
     context 'fetch tokens without filtering' do
       it 'returns tokens' do
         params = build(:api_signed_request, '', api_v1_tokens_path, 'GET')

--- a/spec/decorators/token_decorator_spec.rb
+++ b/spec/decorators/token_decorator_spec.rb
@@ -47,7 +47,11 @@ describe TokenDecorator do
     end
 
     it 'includes url' do
-      expect(token.decorate.logo_url).to start_with('http')
+      expect(token.decorate.logo_url).to start_with('https://')
+    end
+
+    it 'includes custom host' do
+      expect(token.decorate.logo_url(host: 'host')).to start_with('https://host')
     end
   end
 

--- a/spec/decorators/token_decorator_spec.rb
+++ b/spec/decorators/token_decorator_spec.rb
@@ -45,6 +45,10 @@ describe TokenDecorator do
     it 'returns default image' do
       expect(token.reload.decorate.logo_url).to include('image.png')
     end
+
+    it 'includes url' do
+      expect(token.decorate.logo_url).to start_with('http')
+    end
   end
 
   describe 'network' do


### PR DESCRIPTION
Resolve:
https://www.pivotaltracker.com/n/projects/2167210/stories/177321303

Detail:
 * Current GET /api/v1/tokens returns a file link instead of a URL link with the token logo image url:

a spec verifying that Rails.application.routes.url_helpers.url_for(logo_image) as used in the API returns a full path to the image that can be used by clients of the API