### PR TITLE
Change to 10 ci nodes

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         ruby: [2.7.1]
         node: [12.x]
-        ci_node_total: [15]
-        ci_node_index: [0, 1, 2, 3, 4,5,6,7,8,9,10,11,12,13,14]
+        ci_node_total: [10]
+        ci_node_index: [0, 1, 2, 3, 4,5,6,7,8,9]
 
     env:
       KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,7 @@ RSpec.configure do |config|
   #   # order dependency and want to debug it, you can fix the order by providing
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
-  config.order = :random
+  config.order = :defined
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
Reduce the amount of nodes to potentially decrease some of the parallel test failures.