### PR TITLE
Improve performance on Accounts page

### DIFF
--- a/app/views/dashboard/accounts/_summary.html.erb
+++ b/app/views/dashboard/accounts/_summary.html.erb
@@ -16,24 +16,20 @@
   <div class="transfers-table__transfer__max-investment">
     <label>max investment</label>
 
-    <% cache @accounts_all.map(&:latest_verification) do %>
-      <%= number_to_currency(@accounts_all.map(&:latest_verification).compact.sum(&:max_investment_usd)) || '–' %>
-    <% end %>
+    –
   </div>
 
   <div class="transfers-table__transfer__tokens">
     <label>tokens <%= @project.token&.symbol ? "(#{@project.token&.symbol})" : '' %></label>
 
-    <% cache @project.awards do %>
-      <%= @project.total_awards_earned(@accounts_all) %>
-    <% end %>
+    –
   </div>
 
   <% if @project.token %>
     <div class="transfers-table__transfer__address">
       <label>address</label>
 
-      <%= pluralize(@accounts_all.map { |a| a.address_for_blockchain(@project.token._blockchain) }.compact.size, 'account', 'accounts') %>
+      –
     </div>
   <% end %>
 


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/176796169

- Remove heavy summary calculation of all max investments
- Remove heavy summary calculation of number of accounts having wallets
- Remove total awards summary, since it's already present on transfers page

These values don't make much sense in a context of current Accounts page logic.
We can re-introduce them later if needed, with optimised queries.

We didn't have any spec coverage for these values, so removing them without updating the specs.