### PR TITLE
Fix token logo url for invalid tokens, Fix Sentry setup

### DIFF
--- a/app/decorators/token_decorator.rb
+++ b/app/decorators/token_decorator.rb
@@ -24,6 +24,6 @@ class TokenDecorator < Draper::Decorator
   end
 
   def logo_url(host: Rails.application.routes.default_url_options[:host])
-    Rails.application.routes.url_helpers.polymorphic_url(logo_image, host: host)
+    Rails.application.routes.url_helpers.polymorphic_url(logo_image, host: host) if logo_image
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DSN']
+end

--- a/spec/decorators/token_decorator_spec.rb
+++ b/spec/decorators/token_decorator_spec.rb
@@ -53,6 +53,16 @@ describe TokenDecorator do
     it 'includes custom host' do
       expect(token.decorate.logo_url(host: 'host')).to start_with('https://host')
     end
+
+    context 'when image is not present' do
+      before do
+        allow(token).to receive(:logo_image).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(token.decorate.logo_url).to be_nil
+      end
+    end
   end
 
   describe 'network' do


### PR DESCRIPTION
- Return `logo_url` nil if token doesn't have a logo
- Create an initialiser for Sentry