### PR TITLE
Add option to disable SSL for Redis

### DIFF
--- a/app.json
+++ b/app.json
@@ -125,6 +125,10 @@
       "description": "Recaptcha secret key",
       "required": false
     },
+    "REDIS_SSL_NONE": {
+      "description": "Disable SSL for Redis (required by Redis Premium add-on)",
+      "required": false
+    },
     "SIDEKIQ_PASSWORD": {
       "description": "Password for Sidekiq admin panel",
       "generator": "secret"

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,7 +63,18 @@ module Comakery
     # Use Redis for Cache Store
     redis_provider = ENV.fetch("REDIS_PROVIDER") { "REDIS_URL" }
     redis_url = ENV.fetch(redis_provider) { "redis://localhost:6379/1" }
-    config.cache_store = :redis_cache_store, { url: redis_url, expires_in: 1.hour }
+
+    config.custom_redis_params = {}
+
+    # Disable SSL for Redis in Heroku env:
+    # https://help.heroku.com/HC0F8CUS/redis-connection-issues
+    if ENV["REDIS_SSL_NONE"]
+      config.custom_redis_params = {
+        ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+      }
+    end
+
+    config.cache_store = :redis_cache_store, { url: redis_url, expires_in: 1.hour }.merge(config.custom_redis_params)
     config.action_controller.perform_caching = true
 
     # Output logs only to STDOUT

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = Rails.configuration.custom_redis_params
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = Rails.configuration.custom_redis_params
+end


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/177709857

> From version 6 and above, Redis requires using TLS to connect.
However, Heroku does not use SSL internally.

https://help.heroku.com/HC0F8CUS/redis-connection-issues
https://ogirginc.github.io/en/heroku-redis-ssl-error

The issue is only present on Premium Redis add-ons, on free Redis add-ons Heroku does use SSL  🤷
Add ENV `REDIS_SSL_NONE` to trigger the logic.