### PR TITLE
Redirect to the whitelabel domain if it does not match

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
   # require account logins for all pages by default
   # (public pages use skip_before_action :require_login)
   before_action :set_whitelabel_mission
+  before_action :redirect_to_default_whitelabel_domain
   before_action :require_login, :require_email_confirmation, :check_age, :require_build_profile
   before_action :basic_auth
   before_action :set_project_scope
@@ -236,6 +237,13 @@ class ApplicationController < ActionController::Base
 
     redirect_url = current_user ? projects_url : new_session_url
     redirect_to redirect_url
+  end
+
+  def redirect_to_default_whitelabel_domain
+    return unless ENV['WHITELABEL'] == 'true'
+    return if @whitelabel_mission
+
+    redirect_to root_url(host: ENV['APP_HOST'])
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -240,7 +240,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_to_default_whitelabel_domain
-    return unless ENV['WHITELABEL'] == 'true'
+    return if ENV['WHITELABEL'] != 'true'
     return if @whitelabel_mission
 
     redirect_to root_url(host: ENV['APP_HOST'])

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -228,17 +228,9 @@ describe ApplicationController do
     let(:app_host_var) { 'wl.mission.test' }
     let!(:wl_mission) { create(:whitelabel_mission, whitelabel_domain: app_host_var) }
 
-    around(:each) do |example|
-      prev_wl_env = ENV['WHITELABEL']
-      prev_app_host_env = ENV['APP_HOST']
-
-      ENV['WHITELABEL'] = wl_var
-      ENV['APP_HOST'] = app_host_var
-
-      example.run
-
-      ENV['WHITELABEL'] = prev_wl_env
-      ENV['APP_HOST'] = prev_app_host_env
+    before do
+      stub_const('ENV', ENV.to_hash.merge('WHITELABEL' => wl_var))
+      stub_const('ENV', ENV.to_hash.merge('APP_HOST' => app_host_var))
     end
 
     it 'redirects to default domain if the current does not match' do


### PR DESCRIPTION
task: https://www.pivotaltracker.com/story/show/177715579

I've changed the logic a little bit. I decided to not introduce the new ENV because we already have all necessary data.
We can check `ENV['WHITELABEL']` and if it set and @whitelabel_mission is not set => we will redirect to ENV['APP_HOST']
which is the default domain for Whitelabel mission.