### PR TITLE
Fix `/token_balances` API endpoint

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::AccountsController < Api::V1::ApiController
 
   # GET /api/v1/accounts/1/token_balances
   def token_balances
-    account
+    account.sync_balances_later
   end
 
   # POST /api/v1/accounts

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -332,6 +332,12 @@ class Account < ApplicationRecord
     wallets.find_by(_blockchain: blockchain, primary_wallet: true)&.address
   end
 
+  def sync_balances_later
+    balances.find_each do |balance|
+      SyncBalanceJob.set(queue: :critical).perform_later(balance)
+    end
+  end
+
   private
 
     def validate_age

--- a/app/views/api/v1/accounts/token_balances.json.jbuilder
+++ b/app/views/api/v1/accounts/token_balances.json.jbuilder
@@ -1,19 +1,14 @@
-json.array! Token.all.with_attached_logo_image do |token|
-  record = @account.account_token_records.find_by(token: token)
-  next unless record
-
+json.array! @account.balances.includes(:wallet, :token).map do |balance|
   json.token do
-    json.partial! 'api/v1/tokens/token', token: token
+    json.partial! 'api/v1/tokens/token', token: balance.token
   end
 
   json.blockchain do
-    json.address @account.address_for_blockchain(token._blockchain)
-    json.balance record.balance
-    json.max_balance record.max_balance.to_s
-    json.lockup_until record.lockup_until
-    json.account_frozen record.account_frozen
+    json.address balance.wallet.address
+    json.balance balance.base_unit_value
+    json.updated_at balance.updated_at
   end
 
-  json.total_received @account.decorate.total_received_in(token)
-  json.total_received_and_accepted_in @account.decorate.total_received_and_accepted_in(token)
+  json.total_received @account.decorate.total_received_in(balance.token)
+  json.total_received_and_accepted_in @account.decorate.total_received_and_accepted_in(balance.token)
 end

--- a/spec/acceptance/api/v1/12_accounts_spec.rb
+++ b/spec/acceptance/api/v1/12_accounts_spec.rb
@@ -367,16 +367,12 @@ resource 'II. Accounts' do
     context '200' do
       let!(:id) { account.managed_account_id }
       let!(:token) { create(:token, _token_type: :comakery_security_token, contract_address: build(:ethereum_contract_address), _blockchain: :ethereum_ropsten) }
-      let!(:token2) { create(:token, _token_type: :comakery_security_token, contract_address: build(:ethereum_contract_address), _blockchain: :ethereum_ropsten) }
-      let!(:account_token_record) { create(:account_token_record, account: account, token: token) }
-      let!(:account_token_record2) { create(:account_token_record, account: account, token: token2) }
+      let!(:balance) { create(:balance, base_unit_value: 200, token: token, wallet: create(:eth_wallet, account: account)) }
       let!(:award_type) { create(:award_type, project: create(:project, token: token)) }
-      let!(:award_type2) { create(:award_type, project: create(:project, token: token2)) }
 
       before do
         create(:award, account: account, status: :paid, amount: 1, award_type: award_type)
         create(:award, account: account, status: :paid, amount: 2, award_type: award_type)
-        create(:award, account: account, status: :paid, amount: 8, award_type: award_type2)
       end
 
       example 'TOKEN BALANCES' do

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -173,6 +173,8 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
       params[:account_id] = account.managed_account_id
       params[:format] = :json
 
+      expect_any_instance_of(Account).to receive(:sync_balances_later)
+
       get :token_balances, params: params
       expect(response).to be_successful
     end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -763,4 +763,15 @@ describe Account do
       end
     end
   end
+
+  describe '#sync_balances_later' do
+    let!(:account) { create(:balance).wallet.account }
+    subject { account.sync_balances_later }
+
+    it 'schedules balances sync' do
+      expect(SyncBalanceJob).to receive(:set).and_call_original
+      expect_any_instance_of(ActiveJob::ConfiguredJob).to receive(:perform_later)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/177309195

- Return all balances for the account
- Add timestamp to balance response
- Remove AccountTokenRecord related data from response
- Trigger account balances sync when endpoint is called