### PR TITLE
Fix `/token_balances` for non-security tokens

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -333,8 +333,10 @@ class Account < ApplicationRecord
   end
 
   def sync_balances_later
-    balances.find_each do |balance|
-      SyncBalanceJob.set(queue: :critical).perform_later(balance)
+    wallets.find_each do |wallet|
+      wallet.tokens_of_the_blockchain.find_each do |token|
+        Balance.find_or_create_by(token: token, wallet: wallet).sync_with_blockchain_later
+      end
     end
   end
 

--- a/app/models/balance.rb
+++ b/app/models/balance.rb
@@ -20,6 +20,10 @@ class Balance < ApplicationRecord
     update(base_unit_value: blockchain_balance_base_unit_value)
   end
 
+  def sync_with_blockchain_later
+    SyncBalanceJob.set(queue: :critical).perform_later(self)
+  end
+
   # Do not update the balance if it was updated recently but should be updated for just created balance
   def ready_for_balance_update?
     updated_at < 10.seconds.ago || updated_at == created_at

--- a/spec/models/balance_spec.rb
+++ b/spec/models/balance_spec.rb
@@ -41,4 +41,14 @@ describe Balance, type: :model do
       expect(balance.reload.base_unit_value).to eq 999
     end
   end
+
+  describe '#sync_with_blockchain_later' do
+    subject { balance.sync_with_blockchain_later }
+
+    it 'schedules balances sync' do
+      expect(SyncBalanceJob).to receive(:set).and_call_original
+      expect_any_instance_of(ActiveJob::ConfiguredJob).to receive(:perform_later)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/177309195

- Trigger balance record creation from `/token_balances` request