### PR TITLE
remove whitelabel-projects-task

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -232,6 +232,7 @@ class ProjectsController < ApplicationController
 
     def set_show_props # rubocop:todo Metrics/CyclomaticComplexity
       @props = {
+        whitelabel: ENV['WHITELABEL'] || false,
         tasks_by_specialty: @project.ready_tasks_by_specialty.map do |specialty, awards|
           [
             specialty&.name&.downcase || 'general',

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -229,21 +229,25 @@ class ProjectsController < ApplicationController
     def project_header
       @project ? @project.decorate.header_props : { image_url: helpers.image_url('default_project.jpg') }
     end
+    
+    def project_tasks_by_specialty
+      @project.ready_tasks_by_specialty.map do |specialty, awards|
+        [
+          specialty&.name&.downcase || 'general',
+          awards.map do |task|
+            task_to_props(task).merge(
+              allowed_to_start: policy(task).start?,
+              reached_maximum_assignments: task.reached_maximum_assignments_for?(current_account)
+            )
+          end
+        ]
+      end
+    end
 
     def set_show_props # rubocop:todo Metrics/CyclomaticComplexity
       @props = {
         whitelabel: ENV['WHITELABEL'] || false,
-        tasks_by_specialty: @project.ready_tasks_by_specialty.map do |specialty, awards|
-          [
-            specialty&.name&.downcase || 'general',
-            awards.map do |task|
-              task_to_props(task).merge(
-                allowed_to_start: policy(task).start?,
-                reached_maximum_assignments: task.reached_maximum_assignments_for?(current_account)
-              )
-            end
-          ]
-        end,
+        tasks_by_specialty: project_tasks_by_specialty,
         interested: current_account&.interested?(@project.id),
         specialty_interested: [*1..8].map { |specialty_id| current_account&.specialty_interested?(@project.id, specialty_id) },
         project_data: project_props(@project),

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -229,7 +229,7 @@ class ProjectsController < ApplicationController
     def project_header
       @project ? @project.decorate.header_props : { image_url: helpers.image_url('default_project.jpg') }
     end
-    
+
     def project_tasks_by_specialty
       @project.ready_tasks_by_specialty.map do |specialty, awards|
         [

--- a/app/javascript/components/Project.jsx
+++ b/app/javascript/components/Project.jsx
@@ -247,6 +247,7 @@ export default class Project extends React.Component {
       <ProjectSetupHeader
         projectForHeader={this.props.projectForHeader}
         missionForHeader={this.props.missionForHeader}
+        whitelabel={this.props.whitelabel}
         owner={this.props.editable}
         current='overview'
         expanded
@@ -451,6 +452,7 @@ Project.propTypes = {
   interested      : PropTypes.bool,
   csrfToken       : PropTypes.string,
   editable        : PropTypes.bool,
+  whitelabel      : PropTypes.bool,
   myTasksPath     : PropTypes.string,
   editPath        : PropTypes.string,
   missionForHeader: PropTypes.object,

--- a/app/javascript/components/layouts/ProjectSetupHeader.jsx
+++ b/app/javascript/components/layouts/ProjectSetupHeader.jsx
@@ -166,7 +166,7 @@ class ProjectSetupHeader extends React.Component {
                 GitHub
               </NavLink>
               }
-              {(owner || project.showBatches) &&
+              {(owner || project.showBatches) && this.props.whitelabel != true &&
               <NavLink current={current === 'batches'} href={project.batchesUrl}>
                 tasks
               </NavLink>

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -48,7 +48,9 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def show_award_types?
-    show? || unlisted?
+    return false if ENV['WHITELABEL'] == true
+
+    (show? || unlisted?)
   end
 
   def show_transfer_rules?

--- a/spec/features/tasks/project_tasks.spec.rb
+++ b/spec/features/tasks/project_tasks.spec.rb
@@ -13,7 +13,7 @@ describe 'project page', :js do
 
     expect(page).to have_link('Tasks')
     visit(project_award_types_path(ready_task.project))
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_current_path(project_award_types_path(ready_task.project))
   end
 
   it 'shows tasks link if env whitelabel is set to true' do
@@ -22,7 +22,7 @@ describe 'project page', :js do
 
     expect(page).not_to have_link('Tasks')
     visit(project_award_types_path(ready_task.project))
-    expect(page).to have_current_path(project_award_types_path(ready_task.project))
+    expect(page).to have_current_path(root_path)
   end
 
   it 'shows ready tasks to a contributor' do

--- a/spec/features/tasks/project_tasks.spec.rb
+++ b/spec/features/tasks/project_tasks.spec.rb
@@ -7,6 +7,24 @@ describe 'project page', :js do
     ready_task.project.update(visibility: :public_listed)
   end
 
+  it 'shows tasks link if env whitelabel is not true' do
+    login(ready_task.account)
+    visit(project_path(ready_task.project))
+
+    expect(page).to have_link('Tasks')
+    visit(project_award_types_path(ready_task.project))
+    expect(page).to have_current_path(root_path)
+  end
+
+  it 'shows tasks link if env whitelabel is set to true' do
+    login(ready_task.account)
+    visit(project_path(ready_task.project))
+
+    expect(page).not_to have_link('Tasks')
+    visit(project_award_types_path(ready_task.project))
+    expect(page).to have_current_path(project_award_types_path(ready_task.project))
+  end
+
   it 'shows ready tasks to a contributor' do
     login(ready_task.account)
     visit(project_path(ready_task.project))


### PR DESCRIPTION
When the WHITELABEL environment variable is set to true then the project "Tasks" menu item should not appear