### PR TITLE
Fix SendInvite call typo

### DIFF
--- a/app/controllers/projects/invites_controller.rb
+++ b/app/controllers/projects/invites_controller.rb
@@ -6,7 +6,7 @@ class Projects::InvitesController < ApplicationController
   def create
     authorize(project, :project_admin?)
 
-    send_invite_result = SendInvite.call(project: project, whitelable_mission: @whitelabel_mission, params: params)
+    send_invite_result = SendInvite.call(project: project, whitelabel_mission: @whitelabel_mission, params: params)
 
     respond_to do |format|
       if send_invite_result.success?

--- a/spec/controllers/projects/invites_controller_spec.rb
+++ b/spec/controllers/projects/invites_controller_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe Projects::InvitesController, type: :controller do
 
   let!(:params) do
     {
-      project_id: project.id,
+      project_id: project.id.to_s,
       email: 'example@gmail.com',
-      role: :interested
+      role: 'interested'
     }
+  end
+  let(:controller_params) do
+    ActionController::Parameters.new(params.merge(format: 'json', controller: 'projects/invites', action: 'create'))
   end
 
   before do
@@ -22,33 +25,50 @@ RSpec.describe Projects::InvitesController, type: :controller do
   describe 'POST #create' do
     context 'with valid params' do
       it 'creates a new project_role' do
+        expect(SendInvite).to receive(:call).with(project: project, whitelabel_mission: nil, params: controller_params).and_call_original
         expect do
           post :create, params: params, format: :json
         end.to change(ProjectRole, :count).by(1)
+        expect(response).to have_http_status(:created)
       end
 
-      it 'returns a success response' do
-        post :create, params: params, format: :json
-        expect(response).to have_http_status(:created)
+      context 'for whitelabel' do
+        let(:mission) { create(:active_whitelabel_mission) }
+        let!(:admin) { create(:account) }
+        let!(:project) { create(:project, mission: mission) }
+        let!(:account) { create(:account, email: 'example@gmail.com') }
+
+        before do
+          admin.update(managed_mission: mission)
+          account.update(managed_mission: mission)
+        end
+
+        it 'creates a new project_role' do
+          expect(SendInvite).to receive(:call).with(project: project, whitelabel_mission: mission, params: controller_params).and_call_original
+          expect do
+            post :create, params: params, format: :json
+          end.to change(ProjectRole, :count).by(1)
+          expect(response).to have_http_status(:created)
+          expect(project.project_interested.first).to eq account
+        end
       end
     end
 
     context 'with invalid params' do
       let!(:params) do
         {
-          project_id: project.id,
+          project_id: project.id.to_s,
           email: 'unregister@gmail.com',
-          role: :interested
+          role: 'interested'
         }
       end
 
-      it 'respond with errors' do
-        post :create, params: params, format: :json
-        expect(JSON.parse(response.body)['errors']).to eq(['The user must have signed up to add them'])
-      end
+      it 'responds with errors' do
+        expect(SendInvite).to receive(:call).with(project: project, whitelabel_mission: nil, params: controller_params).and_call_original
 
-      it 'returns a fail response' do
         post :create, params: params, format: :json
+
+        expect(JSON.parse(response.body)['errors']).to eq(['The user must have signed up to add them'])
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end


### PR DESCRIPTION
task: https://www.pivotaltracker.com/story/show/178324977

The issue was with typo in calling params: ~~whitelable_mission~~ instead of `whitelabel_mission`
Covered by tests now.