### PR TITLE
Transfers page: Improve showing prioritize button

### DIFF
--- a/app/decorators/award_decorator.rb
+++ b/app/decorators/award_decorator.rb
@@ -102,4 +102,11 @@ class AwardDecorator < Draper::Decorator
       'in-progress--metamask in-progress--metamask__paid'
     end
   end
+
+  def show_prioritize_button?
+    return true if latest_blockchain_transaction.nil?
+    return false if latest_blockchain_transaction.failed? && project.hot_wallet_auto_sending?
+
+    latest_blockchain_transaction.status.in?(%w[created cancelled failed])
+  end
 end

--- a/app/decorators/award_decorator.rb
+++ b/app/decorators/award_decorator.rb
@@ -104,9 +104,15 @@ class AwardDecorator < Draper::Decorator
   end
 
   def show_prioritize_button?
+    return false if project.hot_wallet_disabled?
     return true if latest_blockchain_transaction.nil?
-    return false if latest_blockchain_transaction.failed? && project.hot_wallet_auto_sending?
 
-    latest_blockchain_transaction.status.in?(%w[created cancelled failed])
+    if latest_blockchain_transaction.failed?
+      return project.hot_wallet_manual_sending? if latest_blockchain_transaction.failed?
+    end
+    # return false if latest_blockchain_transaction.failed? && project.hot_wallet_auto_sending?
+    # return true if latest_blockchain_transaction.failed? && project.hot_wallet_manual_sending?
+
+    latest_blockchain_transaction.status.in?(%w[created cancelled])
   end
 end

--- a/app/decorators/award_decorator.rb
+++ b/app/decorators/award_decorator.rb
@@ -106,10 +106,7 @@ class AwardDecorator < Draper::Decorator
   def show_prioritize_button?
     return false if project.hot_wallet_disabled?
     return true if latest_blockchain_transaction.nil?
-
-    if latest_blockchain_transaction.failed?
-      return project.hot_wallet_manual_sending? if latest_blockchain_transaction.failed?
-    end
+    return project.hot_wallet_manual_sending? if latest_blockchain_transaction.failed?
 
     latest_blockchain_transaction.status.in?(%w[created cancelled])
   end

--- a/app/decorators/award_decorator.rb
+++ b/app/decorators/award_decorator.rb
@@ -110,8 +110,6 @@ class AwardDecorator < Draper::Decorator
     if latest_blockchain_transaction.failed?
       return project.hot_wallet_manual_sending? if latest_blockchain_transaction.failed?
     end
-    # return false if latest_blockchain_transaction.failed? && project.hot_wallet_auto_sending?
-    # return true if latest_blockchain_transaction.failed? && project.hot_wallet_manual_sending?
 
     latest_blockchain_transaction.status.in?(%w[created cancelled])
   end

--- a/app/views/shared/_transfer_prioritize_button.html.erb
+++ b/app/views/shared/_transfer_prioritize_button.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "transfer_prioritize_button_#{transfer.id}", target: '_top' do %>
-  <% unless transfer.latest_blockchain_transaction&.pending? %>
+  <% if transfer.show_prioritize_button? %>
     <div class="transfers-table__transfer__button__history">
       <%= link_to prioritize_project_dashboard_transfer_path(project_id: transfer.project.id, id: transfer.id),
                   class: 'transfer-algo-btn',

--- a/spec/decorators/award_decorator_spec.rb
+++ b/spec/decorators/award_decorator_spec.rb
@@ -126,4 +126,57 @@ describe AwardDecorator do
       expect(award.decorate.transfer_button_state_class).to be_nil
     end
   end
+
+  describe '#show_prioritize_button?' do
+    let(:award) { tx.blockchain_transactable.decorate }
+
+    subject { award.show_prioritize_button? }
+
+    context 'for not created tx' do
+      let(:tx) { nil }
+      let(:award) { create(:award).decorate }
+
+      it { is_expected.to be true }
+    end
+
+    context 'for tx with created status' do
+      let(:tx) { create(:blockchain_transaction, status: :created) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'for tx with pending status' do
+      let(:tx) { create(:blockchain_transaction, status: :pending, tx_hash: 'tx hash') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for tx with cancelled status' do
+      let(:tx) { create(:blockchain_transaction, status: :cancelled, tx_hash: 'tx hash') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'for tx with succeed status' do
+      let(:tx) { create(:blockchain_transaction, status: :succeed, tx_hash: 'tx hash') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for tx with failed status' do
+      let(:tx) { create(:blockchain_transaction, status: :failed, tx_hash: 'tx hash') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for tx with failed status and hot wallet in manual mode' do
+      let(:tx) { create(:blockchain_transaction, status: :failed, tx_hash: 'tx hash') }
+
+      before do
+        award.project.hot_wallet_manual_sending!
+      end
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/decorators/award_decorator_spec.rb
+++ b/spec/decorators/award_decorator_spec.rb
@@ -129,14 +129,27 @@ describe AwardDecorator do
 
   describe '#show_prioritize_button?' do
     let(:award) { tx.blockchain_transactable.decorate }
+    let(:hot_wallet_mode) { :auto_sending }
 
     subject { award.show_prioritize_button? }
+
+    before do
+      award.project.update!(hot_wallet_mode: hot_wallet_mode)
+    end
 
     context 'for not created tx' do
       let(:tx) { nil }
       let(:award) { create(:award).decorate }
 
       it { is_expected.to be true }
+    end
+
+    context 'for not created tx and disabled hot wallet mode' do
+      let(:tx) { nil }
+      let(:award) { create(:award).decorate }
+      let(:hot_wallet_mode) { :disabled }
+
+      it { is_expected.to be false }
     end
 
     context 'for tx with created status' do
@@ -171,10 +184,7 @@ describe AwardDecorator do
 
     context 'for tx with failed status and hot wallet in manual mode' do
       let(:tx) { create(:blockchain_transaction, status: :failed, tx_hash: 'tx hash') }
-
-      before do
-        award.project.hot_wallet_manual_sending!
-      end
+      let(:hot_wallet_mode) { :manual_sending }
 
       it { is_expected.to be true }
     end

--- a/spec/features/dashboard/transfers/transfer_prioritize_button_spec.rb
+++ b/spec/features/dashboard/transfers/transfer_prioritize_button_spec.rb
@@ -9,7 +9,7 @@ describe 'transfer prioritize button on transfers page', js: true do
 
   before { create(:wallet, source: :hot_wallet, project_id: project.id) }
 
-  before { project.update(hot_wallet_mode: :auto_sending) }
+  before { project.update!(hot_wallet_mode: :auto_sending) }
 
   before { transfer.accepted! }
 
@@ -34,12 +34,12 @@ describe 'transfer prioritize button on transfers page', js: true do
       it 'isn\'t present' do
         visit project_dashboard_transfers_path(project)
 
-        expect(page).not_to have_css('.transfers-table__transfer__button__history #prioritizeBtn')
+        expect(page).to have_no_css('.transfers-table__transfer__button__history #prioritizeBtn')
       end
     end
 
-    context 'with succeed status' do
-      before { blockchain_transaction.update(status: :succeed) }
+    context 'with created status' do
+      before { blockchain_transaction.update(status: :created) }
 
       context 'when hot wallet mode is auto sending' do
         it 'has link to prioritize' do


### PR DESCRIPTION
task: https://www.pivotaltracker.com/story/show/177918187

Prioritize button should be hidden for:
- disabled hot wallet mode
- if last transaction is failed and hw mode is auto sending
- for last transaction in pending or succeed status