### PR TITLE
Send decorated model for all broadcast methods

### DIFF
--- a/app/decorators/wallet_decorator.rb
+++ b/app/decorators/wallet_decorator.rb
@@ -1,0 +1,3 @@
+class WalletDecorator < Draper::Decorator
+  delegate_all
+end

--- a/app/models/blockchain_transaction_award.rb
+++ b/app/models/blockchain_transaction_award.rb
@@ -42,7 +42,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_history_button_#{blockchain_transactable.id}",
         partial: 'dashboard/transfers/transfer_history_button',
-        locals: { transfer: blockchain_transactable }
+        locals: { transfer: blockchain_transactable.decorate }
       )
 
       broadcast_replace_later_to(
@@ -66,7 +66,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_button_public_#{blockchain_transactable.id}",
         partial: 'shared/transfer_button_public',
-        locals: { transfer: blockchain_transactable }
+        locals: { transfer: blockchain_transactable.decorate }
       )
 
       broadcast_replace_later_to(
@@ -74,7 +74,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_button_admin_#{blockchain_transactable.id}",
         partial: 'shared/transfer_button_admin',
-        locals: { transfer: blockchain_transactable }
+        locals: { transfer: blockchain_transactable.decorate }
       )
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -296,20 +296,24 @@ class Project < ApplicationRecord
     def broadcast_hot_wallet_mode
       broadcast_replace_later_to 'project_hot_wallet_modes',
                                  target: "project_#{id}_hot_wallet_mode",
-                                 partial: 'dashboard/transfers/hot_wallet_mode', locals: { project: self }
+                                 partial: 'dashboard/transfers/hot_wallet_mode',
+                                 locals: { project: decorate }
 
       broadcast_replace_later_to "transfer_project_#{id}_hot_wallet_mode",
                                  target: "transfer_project_#{id}_hot_wallet_mode",
-                                 partial: 'shared/transfer_prioritize_button/mode', locals: { project: self }
+                                 partial: 'shared/transfer_prioritize_button/mode',
+                                 locals: { project: decorate }
     end
 
     def broadcast_batch_size
       broadcast_replace_later_to 'project_transfer_batch_size',
                                  target: "project_#{id}_transfer_batch_size",
-                                 partial: 'dashboard/transfers/batch_size', locals: { project: self }
+                                 partial: 'dashboard/transfers/batch_size',
+                                 locals: { project: decorate }
 
       broadcast_replace_later_to 'project_transfer_batch_size_modal_form',
                                  target: "project_#{id}_transfer_batch_size_modal_form",
-                                 partial: 'projects/batch_size_modal_form', locals: { project: self }
+                                 partial: 'projects/batch_size_modal_form',
+                                 locals: { project: decorate }
     end
 end

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -22,7 +22,7 @@ class Verification < ApplicationRecord
         broadcast_replace_to "mission_#{account.managed_mission&.id}_account_wallets",
                              target: "account_#{account.id}_wallet_#{wallet.id}",
                              partial: 'accounts/partials/index/wallet',
-                             locals: { wallet: wallet }
+                             locals: { wallet: wallet.decorate }
       end
     end
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -114,14 +114,14 @@ class Wallet < ApplicationRecord
       broadcast_append_later_to "mission_#{account.managed_mission&.id}_account_wallets",
                                 target: "account_#{account.id}_wallet_#{id}",
                                 partial: 'accounts/partials/index/wallet',
-                                locals: { wallet: self }
+                                locals: { wallet: decorate }
     end
 
     def broadcast_update
       broadcast_replace_to "mission_#{account.managed_mission&.id}_account_wallets",
                            target: "account_#{account.id}_wallet_#{id}",
                            partial: 'accounts/partials/index/wallet',
-                           locals: { wallet: self }
+                           locals: { wallet: decorate }
     end
 
     def broadcast_destroy


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/178418211

Let's set as a rule to always send decorated model for `broadcast_*` method from a model.

