### PR TITLE
Force update of `Balance#updated_at`

### DIFF
--- a/app/models/balance.rb
+++ b/app/models/balance.rb
@@ -52,7 +52,8 @@ class Balance < ApplicationRecord
     update!(
       base_unit_value: blockchain_balance_base_unit_value,
       base_unit_locked_value: blockchain_balance_base_unit_locked_value,
-      base_unit_unlocked_value: blockchain_balance_base_unit_unlocked_value
+      base_unit_unlocked_value: blockchain_balance_base_unit_unlocked_value,
+      updated_at: Time.current
     )
   end
 

--- a/spec/models/balance_spec.rb
+++ b/spec/models/balance_spec.rb
@@ -206,6 +206,18 @@ describe Balance, type: :model do
       expect(balance.base_unit_locked_value).to eq 999
       expect(balance.base_unit_unlocked_value).to eq 999
     end
+
+    context 'when values are not changed' do
+      before do
+        allow(balance.token).to receive(:blockchain_balance).with(balance.wallet.address).and_return(0)
+        allow(balance.token).to receive(:blockchain_locked_balance).with(balance.wallet.address).and_return(0)
+        allow(balance.token).to receive(:blockchain_unlocked_balance).with(balance.wallet.address).and_return(0)
+      end
+
+      it 'still updates timestamp' do
+        expect { subject }.to change(balance, :updated_at)
+      end
+    end
   end
 
   describe '#sync_with_blockchain_later' do


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/178418121

I was thinking about it and looks like adding a `synced_at` column  will
not make much sense, since it would be always equal to `updated_at` (changing
`synced_at` will trigger `updated_at`).

So enforcing `updated_at` directly during balance sync.