### PR TITLE
Enable Ethereum ORE ID support, Fix transfers page payments

### DIFF
--- a/app.json
+++ b/app.json
@@ -82,7 +82,7 @@
       "value": "false"
     },
     "OREID_BASE_DOMAIN": {
-      "description": "Aikon ORE ID API domain (default: staging.service.oreid.io)",
+      "description": "Aikon ORE ID API domain (default: service.oreid.io)",
       "required": false
     },
     "ORE_ID_API_KEY": {

--- a/app/controllers/dashboard/accounts_controller.rb
+++ b/app/controllers/dashboard/accounts_controller.rb
@@ -46,14 +46,14 @@ class Dashboard::AccountsController < ApplicationController
     account_token_record.lockup_until = Time.zone.parse(account_token_record_params[:lockup_until])
 
     if account_token_record.save
-      # TODO: Add a blockchain flag whether a tx should by processed by OREID UI, regardless OREID blockchain support
-      if account_token_record.token.blockchain.supported_by_ore_id?
-        redirect_to sign_ore_id_new_path(account_token_record_id: account_token_record.id)
-      elsif account_token_record.token.blockchain.supported_by_wallet_connect?
+      case request.headers['X-Sign-Controller']
+      when 'metamask', 'wallet-connect'
         render json: {
           tx_new_url: sign_user_wallet_new_path(account_token_record_id: account_token_record.id),
           tx_receive_url: sign_user_wallet_receive_path
         }
+      when 'ore-id'
+        redirect_to sign_ore_id_new_path(account_token_record_id: account_token_record.id)
       else
         @account_token_record = account_token_record
 

--- a/app/controllers/dashboard/transfer_rules_controller.rb
+++ b/app/controllers/dashboard/transfer_rules_controller.rb
@@ -21,13 +21,14 @@ class Dashboard::TransferRulesController < ApplicationController
     transfer_rule.lockup_until = Time.zone.parse(transfer_rule_params[:lockup_until])
 
     if transfer_rule.save
-      if transfer_rule.token.blockchain.supported_by_ore_id?
-        redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
-      elsif transfer_rule.token.blockchain.supported_by_wallet_connect?
+      case request.headers['X-Sign-Controller']
+      when 'metamask', 'wallet-connect'
         render json: {
           tx_new_url: sign_user_wallet_new_path(transfer_rule_id: transfer_rule.id),
           tx_receive_url: sign_user_wallet_receive_path
         }
+      when 'ore-id'
+        redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
       end
     else
       redirect_to project_dashboard_transfer_rules_path(@project), flash: { error: transfer_rule.errors.full_messages.join(', ') }
@@ -41,13 +42,14 @@ class Dashboard::TransferRulesController < ApplicationController
     transfer_rule.status = nil
     transfer_rule.save!
 
-    if transfer_rule.token.blockchain.supported_by_ore_id?
-      redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
-    elsif transfer_rule.token.blockchain.supported_by_wallet_connect?
+    case request.headers['X-Sign-Controller']
+    when 'metamask', 'wallet-connect'
       render json: {
         tx_new_url: sign_user_wallet_new_path(transfer_rule_id: transfer_rule.id),
         tx_receive_url: sign_user_wallet_receive_path
       }
+    when 'ore-id'
+      redirect_to sign_ore_id_new_path(transfer_rule_id: transfer_rule.id)
     end
   end
 

--- a/app/decorators/award_decorator.rb
+++ b/app/decorators/award_decorator.rb
@@ -10,9 +10,9 @@ class AwardDecorator < Draper::Decorator
   end
 
   def recipient_wallet_address
-    return unless paid?
+    return unless recipient_wallet
 
-    blockchain_transactions.succeed.last&.destination
+    recipient_wallet.address
   end
 
   def sender_wallet_url
@@ -22,7 +22,7 @@ class AwardDecorator < Draper::Decorator
   end
 
   def recipient_wallet_url
-    return if sender_wallet_address.blank?
+    return if recipient_wallet_address.blank?
 
     token&.blockchain&.url_for_address_human(recipient_wallet_address)
   end

--- a/app/javascript/controllers/sign/metamask_controller.js
+++ b/app/javascript/controllers/sign/metamask_controller.js
@@ -134,6 +134,7 @@ export default class extends Controller {
         body: new FormData(form),
         method: form.method,
         headers: {
+          'X-Sign-Controller': this.name,
           'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
         }
       }

--- a/app/javascript/controllers/sign/ore_id_controller.js
+++ b/app/javascript/controllers/sign/ore_id_controller.js
@@ -101,6 +101,7 @@ export default class extends Controller {
         body: new FormData(form),
         method: form.method,
         headers: {
+          'X-Sign-Controller': this.name,
           'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
         }
       }

--- a/app/javascript/controllers/sign/wallet_connect_controller.js
+++ b/app/javascript/controllers/sign/wallet_connect_controller.js
@@ -164,6 +164,7 @@ export default class extends Controller {
         body: new FormData(form),
         method: form.method,
         headers: {
+          'X-Sign-Controller': this.name,
           'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
         }
       }

--- a/app/javascript/controllers/sign/wallet_connect_controller.js
+++ b/app/javascript/controllers/sign/wallet_connect_controller.js
@@ -8,6 +8,10 @@ import PubSub from 'pubsub-js'
 export default class extends Controller {
   static targets = [ "walletAddress", "txButtons", "connectButton", "otherConnectButtons" ]
 
+  initialize() {
+    this.name = 'wallet-connect'
+  }
+
   async walletConnectInit() {
     const bridge = "https://bridge.walletconnect.org"
     const connector = new WalletConnect({ bridge, qrcodeModal: QRCodeModal })
@@ -81,8 +85,10 @@ export default class extends Controller {
     this.txButtonsTargets.forEach(button => {
       if (this.connector && this.connector.connected) {
         button.classList.add('transfer-tokens-btn__enabled')
+        button.dataset.connectedController = this.name
       } else {
         button.classList.remove('transfer-tokens-btn__enabled')
+        button.dataset.connectedController = null
       }
     })
   }
@@ -110,6 +116,11 @@ export default class extends Controller {
     e.preventDefault()
 
     const button = e.target.closest("a")
+
+    if (button.dataset.connectedController !== this.name) {
+      return
+    }
+
     button.classList.remove('transfer-tokens-btn__enabled')
     
     let dataset

--- a/app/javascript/controllers/transfer_types_controller.js
+++ b/app/javascript/controllers/transfer_types_controller.js
@@ -4,13 +4,13 @@ export default class extends Controller {
   static targets = [ 'transferType' ];
 
   updateTransferFormSrc() {
-    let transferTypeId = $(this.transferTypeTarget).data('transferTypeId');
-    let transferFormSelector = $('#transfer_form');
-    let path = transferFormSelector.attr('src').split('?').shift();
+    let transferTypeId = $(this.transferTypeTarget).data('transferTypeId')
+    let transferFormSelector = $('#transfer_form')
+    let path = transferFormSelector.attr('src').split('?').shift()
 
-    transferFormSelector.attr('src', `${path}?award[transfer_type_id]=${transferTypeId}`);
+    transferFormSelector.attr('src', `${path}?award[transfer_type_id]=${transferTypeId}`)
 
     // Disable lazy load of transfer form to be able to send new request with different transferTypeId
-    transferFormSelector.attr('loading', '');
+    transferFormSelector.attr('loading', '')
   }
 }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -335,6 +335,10 @@ class Account < ApplicationRecord
     wallets.find_by(_blockchain: blockchain, primary_wallet: true)&.address
   end
 
+  def ore_id_address_for_blockchain(blockchain)
+    wallets.find_by(_blockchain: blockchain, source: :ore_id, primary_wallet: true)&.address
+  end
+
   def wallets_for_blockchain(blockchain)
     wallets.where(_blockchain: blockchain)
   end

--- a/app/models/blockchain/ethereum.rb
+++ b/app/models/blockchain/ethereum.rb
@@ -101,7 +101,7 @@ class Blockchain::Ethereum < Blockchain
   # Is it supported by OreId service
   # @return [Boolean] flag
   def supported_by_ore_id?
-    false
+    self.class.ore_id_configured? && true
   end
 
   # Name of the blockchain on OreId service, if supported

--- a/app/models/ore_id_service.rb
+++ b/app/models/ore_id_service.rb
@@ -5,7 +5,7 @@ class OreIdService
 
   include HTTParty
 
-  BASE_DOMAIN = ENV.fetch('OREID_BASE_DOMAIN', 'staging.service.oreid.io')
+  BASE_DOMAIN = ENV.fetch('OREID_BASE_DOMAIN', 'service.oreid.io')
   base_uri "https://#{BASE_DOMAIN}/api"
 
   attr_reader :ore_id, :account

--- a/app/views/dashboard/transfers/_filters.html.erb
+++ b/app/views/dashboard/transfers/_filters.html.erb
@@ -104,6 +104,7 @@
       </div>
     </div>
   <% end %>
+
   <% if policy(@project).create_transfer? %>
     <%= render partial: 'shared/wallet_connect' %>
   <% end %>

--- a/app/views/dashboard/transfers/edit.html.erb
+++ b/app/views/dashboard/transfers/edit.html.erb
@@ -1,3 +1,3 @@
 <turbo-frame id="transfer_form_<%= @transfer.id %>">
   <%= render partial: "form" %>
-</turbo>
+</turbo-frame>

--- a/app/views/dashboard/transfers/index.html.erb
+++ b/app/views/dashboard/transfers/index.html.erb
@@ -1,5 +1,8 @@
 <%= render layout: 'projects/project_settings' do %>
-  <div data-controller="sign--wallet-connect sign--metamask">
+  <div
+    data-controller="sign--wallet-connect sign--metamask sign--ore-id"
+    data-sign--ore-id-address-value='<%= current_account.ore_id_address_for_blockchain(@project.token._blockchain) %>'
+    data-sign--ore-id-link-url-value='<%= wallets_path %>'>
     <%= render partial: 'filters' %>
     <turbo-frame id="chart-data"
                  target="_top"

--- a/app/views/dashboard/transfers/index.html.erb
+++ b/app/views/dashboard/transfers/index.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: 'projects/project_settings' do %>
   <div
     data-controller="sign--wallet-connect sign--metamask sign--ore-id"
-    data-sign--ore-id-address-value='<%= current_account.ore_id_address_for_blockchain(@project.token._blockchain) %>'
+    data-sign--ore-id-address-value='<%= current_account&.ore_id_address_for_blockchain(@project.token&._blockchain) %>'
     data-sign--ore-id-link-url-value='<%= wallets_path %>'>
     <%= render partial: 'filters' %>
     <turbo-frame id="chart-data"

--- a/app/views/dashboard/transfers/new.html.erb
+++ b/app/views/dashboard/transfers/new.html.erb
@@ -1,3 +1,3 @@
 <turbo-frame id="transfer_form">
   <%= render partial: "form" %>
-</turbo>
+</turbo-frame>

--- a/app/views/shared/_transfer_button_admin.html.erb
+++ b/app/views/shared/_transfer_button_admin.html.erb
@@ -9,21 +9,17 @@
     <% elsif transfer.recipient_address.blank? %>
       needs wallet
 
-    <% elsif transfer.token.blockchain.supported_by_ore_id? %>
-      <%= button_to sign_ore_id_new_path(transfer_id: transfer.id), class: 'transfer-algo-btn', rel: 'nofollow', method: :post, data: {turbo: "false"} do %>
-        <%= render partial: "shared/wallet_logo", locals: { project: transfer.project, size: 12 } %>
-        <span>PAY</span>
-      <% end %>
-
-    <% elsif transfer.token.blockchain.supported_by_wallet_connect? %>
+    <% elsif transfer.token.blockchain.supported_by_wallet_connect? || transfer.token.blockchain.supported_by_ore_id? %>
       <a
         href='javascript:void(0)'
         class="transfer-tokens-btn transfer-tokens-btn-skip-legacy"
-        data-action="click->sign--wallet-connect#sendTx click->sign--metamask#sendTx"
+        data-action="click->sign--wallet-connect#sendTx click->sign--metamask#sendTx click->sign--ore-id#sendTx"
+        data-sign--ore-id-target='txButtons'
         data-sign--wallet-connect-target='txButtons'
         data-sign--metamask-target='txButtons'
         data-tx-new-url="<%= sign_user_wallet_new_path(transfer_id: transfer.id) %>"
-        data-tx-receive-url="<%= sign_user_wallet_receive_path %>">
+        data-tx-receive-url="<%= sign_user_wallet_receive_path %>"
+        data-tx-oreid-new-url="<%= sign_ore_id_new_path(transfer_id: transfer.id) %>">
 
         <% case transfer.latest_blockchain_transaction&.status %>
         <% when 'created' %>

--- a/app/views/shared/_wallet_connect.html.erb
+++ b/app/views/shared/_wallet_connect.html.erb
@@ -1,38 +1,58 @@
-<% if @project.token&.blockchain&.supported_by_wallet_connect? %>
+<% if @project.token&.blockchain&.supported_by_wallet_connect? || @project.token&.blockchain&.supported_by_ore_id? %>
   <div class="col-md-10 wallet-connect">
     <div class="d-flex flex-row justify-content-end">
-      <div
-        class="p-2 wallet-connect--button"
-        data-action='click->sign--wallet-connect#switch'
-        data-sign--wallet-connect-target='connectButton'
-        data-sign--metamask-target='otherConnectButtons'>
-        <span class="wallet-logo">
-          <%= image_tag 'wallet-connect-logo.svg', size: "12x12" %>
-        </span>
-        WalletConnect
-        <span class="wallet-connect--button--dot">●</span>
-      </div>
+      <% if @project.token&.blockchain&.supported_by_wallet_connect? %>
+        <div
+          class="p-2 wallet-connect--button"
+          data-action='click->sign--wallet-connect#switch'
+          data-sign--ore-id-target='otherConnectButtons'
+          data-sign--wallet-connect-target='connectButton'
+          data-sign--metamask-target='otherConnectButtons'>
+          <span class="wallet-logo">
+            <%= image_tag 'wallet-connect-logo.svg', size: "12x12" %>
+          </span>
+          WalletConnect
+          <span class="wallet-connect--button--dot">●</span>
+        </div>
 
-      <div
-        class="p-2 wallet-connect--button"
-        data-action='click->sign--metamask#switch'
-        data-sign--wallet-connect-target='otherConnectButtons'
-        data-sign--metamask-target='connectButton'>
-        <span class="wallet-logo">
-          <%= image_tag 'metamask.png', size: "12x12" %>
-        </span>
-        MetaMask
-        <span class="wallet-connect--button--dot">●</span>
-      </div>
+        <div
+          class="p-2 wallet-connect--button"
+          data-action='click->sign--metamask#switch'
+          data-sign--ore-id-target='otherConnectButtons'
+          data-sign--wallet-connect-target='otherConnectButtons'
+          data-sign--metamask-target='connectButton'>
+          <span class="wallet-logo">
+            <%= image_tag 'metamask.png', size: "12x12" %>
+          </span>
+          MetaMask
+          <span class="wallet-connect--button--dot">●</span>
+        </div>
+      <% end %>
+
+      <% if @project.token&.blockchain&.supported_by_ore_id? %>
+        <div
+          class="p-2 wallet-connect--button"
+          data-action='click->sign--ore-id#switch'
+          data-sign--ore-id-target='connectButton'
+          data-sign--wallet-connect-target='otherConnectButtons'
+          data-sign--metamask-target='otherConnectButtons'>
+          <span class="wallet-logo">
+            <%= image_tag 'OREID_Logo_Symbol.svg', size: "12x12" %>
+          </span>
+          ORE ID
+          <span class="wallet-connect--button--dot">●</span>
+        </div>
+      <% end %>
     </div>
   </div>
+
   <div class="col-md-2 wallet-connect-status">
     <div
-      class="p-2 wallet-connect--address"
+      class="p-2 text-truncate wallet-connect--address"
       data-sign--wallet-connect-target='walletAddress'
-      data-sign--metamask-target='walletAddress'>
+      data-sign--metamask-target='walletAddress'
+      data-sign--ore-id-target='walletAddress'>
       Disconnected
     </div>
   </div>
-</div>
 <% end %>

--- a/public/doc/api/v1/ix._wallets/get_reset_password_url_(only_ore_id_wallets).html
+++ b/public/doc/api/v1/ix._wallets/get_reset_password_url_(only_ore_id_wallets).html
@@ -209,7 +209,7 @@ table th, table td {
             <pre class="response status">200 OK</pre>
               <h4>Body</h4>
               <pre class="response body">{
-  &quot;resetUrl&quot;: &quot;https://staging.service.oreid.io/recover-account?account=ore_id_account_dummy&amp;app_access_token=dummy_token&amp;background_color=FFFFFF&amp;callback_url=localhost&amp;email=me%2Bcc4b6d000417106d1cbbb357ebadd3a0560718bb%40example.com&amp;provider=email&amp;recover_action=republic&amp;state=&amp;hmac=5RclbdcWm1y%2BSI0THzjCmkrYcBWt%2FT0FPtNdJwl0NjQ%3D&quot;
+  &quot;resetUrl&quot;: &quot;https://service.oreid.io/recover-account?account=ore_id_account_dummy&amp;app_access_token=dummy_token&amp;background_color=FFFFFF&amp;callback_url=localhost&amp;email=me%2Bcc4b6d000417106d1cbbb357ebadd3a0560718bb%40example.com&amp;provider=email&amp;recover_action=republic&amp;state=&amp;hmac=5RclbdcWm1y%2BSI0THzjCmkrYcBWt%2FT0FPtNdJwl0NjQ%3D&quot;
 }</pre>
       </div>
     </div>

--- a/public/doc/api/v1/xiii._full_wallet_configurations_flow/3._get_password_reset_link_for_eth_ore_id_wallet_created.html
+++ b/public/doc/api/v1/xiii._full_wallet_configurations_flow/3._get_password_reset_link_for_eth_ore_id_wallet_created.html
@@ -158,7 +158,7 @@ table th, table td {
             <pre class="response status">200 OK</pre>
               <h4>Body</h4>
               <pre class="response body">{
-  &quot;resetUrl&quot;: &quot;https://staging.service.oreid.io/recover-account?account=ore_id_account_dummy&amp;app_access_token=dummy_token&amp;background_color=FFFFFF&amp;callback_url=localhost&amp;email=me%2Bcc4b6d000417106d1cbbb357ebadd3a0560718bb%40example.com&amp;provider=email&amp;recover_action=republic&amp;state=&amp;hmac=5RclbdcWm1y%2BSI0THzjCmkrYcBWt%2FT0FPtNdJwl0NjQ%3D&quot;
+  &quot;resetUrl&quot;: &quot;https://service.oreid.io/recover-account?account=ore_id_account_dummy&amp;app_access_token=dummy_token&amp;background_color=FFFFFF&amp;callback_url=localhost&amp;email=me%2Bcc4b6d000417106d1cbbb357ebadd3a0560718bb%40example.com&amp;provider=email&amp;recover_action=republic&amp;state=&amp;hmac=5RclbdcWm1y%2BSI0THzjCmkrYcBWt%2FT0FPtNdJwl0NjQ%3D&quot;
 }</pre>
       </div>
     </div>

--- a/spec/controllers/algorand_opt_ins_controller_spec.rb
+++ b/spec/controllers/algorand_opt_ins_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe AlgorandOptInsController, type: :controller do
       allow_any_instance_of(OreIdService).to receive(:create_token).and_return('dummy_token')
 
       post :create, params: { wallet_id: wallet.id, token_id: asset_token.id }
-      expect(response).to redirect_to %r{^https://staging.service.oreid.io/sign?}
+      expect(response).to redirect_to %r{^https://service.oreid.io/sign?}
     end
   end
 end

--- a/spec/controllers/api/v1/wallets_controller_spec.rb
+++ b/spec/controllers/api/v1/wallets_controller_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe Api::V1::WalletsController, type: :controller do
         parsed_response = JSON.parse(response.body)
         parsed_reset_url = URI.parse(parsed_response['reset_url'])
 
-        expect(parsed_reset_url.host).to eq 'staging.service.oreid.io'
+        expect(parsed_reset_url.host).to eq 'service.oreid.io'
         expect(parsed_reset_url.path).to eq '/recover-account'
         expect(Rack::Utils.parse_nested_query(parsed_reset_url.query)).to eq(
           'account' => 'ore_id_account_dummy',

--- a/spec/controllers/dashboard/accounts_controller_spec.rb
+++ b/spec/controllers/dashboard/accounts_controller_spec.rb
@@ -147,7 +147,11 @@ RSpec.describe Dashboard::AccountsController, type: :controller do
         expect(account_token_record.wallet).to eq new_account.wallets.first
       end
 
-      context 'with a token supported by wallet connect' do
+      context 'with a request coming from wallet connect controller' do
+        before do
+          request.headers['X-Sign-Controller'] = 'wallet-connect'
+        end
+
         render_views
 
         it 'renders json' do
@@ -158,8 +162,25 @@ RSpec.describe Dashboard::AccountsController, type: :controller do
         end
       end
 
-      context 'with a token supported by ore id', :vcr do
-        let(:account_token_record) { create(:blockchain_transaction_account_token_record_algo).blockchain_transactable }
+      context 'with a request coming from metamask controller' do
+        before do
+          request.headers['X-Sign-Controller'] = 'metamask'
+        end
+
+        render_views
+
+        it 'renders json' do
+          subject
+          expect(response).to have_http_status(:success)
+          expect(JSON.parse(response.body)).to include('tx_new_url')
+          expect(JSON.parse(response.body)).to include('tx_receive_url')
+        end
+      end
+
+      context 'with a request coming from ore-id controller', :vcr do
+        before do
+          request.headers['X-Sign-Controller'] = 'ore-id'
+        end
 
         it 'redirects to ore_id' do
           subject

--- a/spec/features/dashboard/transfers/transfer_button_spec.rb
+++ b/spec/features/dashboard/transfers/transfer_button_spec.rb
@@ -122,11 +122,19 @@ describe 'transfer button on Transfers page' do
 
         context 'and admin has OREID linked' do
           before do
+            BlockchainTransaction.delete_all
             subject
           end
 
-          it 'links to OREID' do
-            expect(page).to have_css('.transfers-table__transfer__status .transfer-button', count: 1, text: 'PAY')
+          it 'links to WalletConnect, Metamask and ORE ID controllers' do
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button', count: 1, text: 'Pay')
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-action="click->sign--wallet-connect#sendTx click->sign--metamask#sendTx click->sign--ore-id#sendTx"]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-sign--wallet-connect-target="txButtons"]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-sign--metamask-target="txButtons"]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-sign--ore-id-target="txButtons"]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-tx-new-url^=\/]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-tx-receive-url^=\/]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-tx-oreid-new-url^=\/]', count: 1)
           end
         end
       end
@@ -244,13 +252,15 @@ describe 'transfer button on Transfers page' do
             subject
           end
 
-          it 'links to WalletConnect and Metamask controllers' do
+          it 'links to WalletConnect, Metamask and ORE ID controllers' do
             expect(page).to have_css('.transfers-table__transfer__status .transfer-button', count: 1, text: 'Pay')
-            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-action="click->sign--wallet-connect#sendTx click->sign--metamask#sendTx"]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-action="click->sign--wallet-connect#sendTx click->sign--metamask#sendTx click->sign--ore-id#sendTx"]', count: 1)
             expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-sign--wallet-connect-target="txButtons"]', count: 1)
             expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-sign--metamask-target="txButtons"]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-sign--ore-id-target="txButtons"]', count: 1)
             expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-tx-new-url^=\/]', count: 1)
             expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-tx-receive-url^=\/]', count: 1)
+            expect(page).to have_css('.transfers-table__transfer__status .transfer-button a[data-tx-oreid-new-url^=\/]', count: 1)
           end
         end
       end

--- a/spec/features/dashboard/wallet_connect_spec.rb
+++ b/spec/features/dashboard/wallet_connect_spec.rb
@@ -10,16 +10,6 @@ shared_examples 'having wallet connect button' do |attrs|
 
   subject { visit send(attrs[:path_helper], project) }
 
-  context 'with a token not supported by WalletConnect and Metamask' do
-    before do
-      subject
-    end
-
-    it 'is not present' do
-      expect(page).not_to have_css('.wallet-connect--button')
-    end
-  end
-
   context 'without a token', unless: attrs[:requires_token] do
     before do
       transfer.ready!
@@ -32,7 +22,30 @@ shared_examples 'having wallet connect button' do |attrs|
     end
   end
 
-  context 'with a token supported by WalletConnect and Metamask' do
+  context 'with a token supported by OREID' do
+    context 'and logged in as project admin' do
+      before do
+        transfer.ready!
+        login(project.account)
+        subject
+      end
+
+      it 'links to OREID stimulus controller' do
+        expect(page).to have_css('.wallet-connect--button', count: 1, text: 'ORE ID')
+        expect(page).to have_css('.wallet-connect--button[data-action="click->sign--ore-id#switch"]', count: 1)
+        expect(page).to have_css('.wallet-connect--button[data-sign--ore-id-target="connectButton"]', count: 1)
+        expect(page).to have_css('.wallet-connect--button .wallet-logo')
+      end
+
+      it 'has address element' do
+        expect(page).to have_css('.wallet-connect--address', count: 1, text: 'Disconnected')
+        expect(page).to have_css('.wallet-connect--address[data-sign--wallet-connect-target="walletAddress"]', count: 1)
+        expect(page).to have_css('.wallet-connect--address[data-sign--metamask-target="walletAddress"]', count: 1)
+      end
+    end
+  end
+
+  context 'with a token supported by WalletConnect, Metamask and OREID' do
     let!(:transfer) { build(:blockchain_transaction).blockchain_transactable }
     let!(:project) { transfer.project }
 
@@ -66,16 +79,24 @@ shared_examples 'having wallet connect button' do |attrs|
       it 'links to WalletConnect stimulus controller' do
         expect(page).to have_css('.wallet-connect--button', count: 1, text: 'WalletConnect')
         expect(page).to have_css('.wallet-connect--button[data-action="click->sign--wallet-connect#switch"]', count: 1)
+        expect(page).to have_css('.wallet-connect--button[data-sign--wallet-connect-target="otherConnectButtons"]', count: 2)
         expect(page).to have_css('.wallet-connect--button[data-sign--wallet-connect-target="connectButton"]', count: 1)
-        expect(page).to have_css('.wallet-connect--button[data-sign--metamask-target="otherConnectButtons"]', count: 1)
         expect(page).to have_css('.wallet-connect--button .wallet-logo')
       end
 
       it 'links to MetaMask stimulus controller' do
         expect(page).to have_css('.wallet-connect--button', count: 1, text: 'MetaMask')
         expect(page).to have_css('.wallet-connect--button[data-action="click->sign--metamask#switch"]', count: 1)
-        expect(page).to have_css('.wallet-connect--button[data-sign--wallet-connect-target="otherConnectButtons"]', count: 1)
+        expect(page).to have_css('.wallet-connect--button[data-sign--metamask-target="otherConnectButtons"]', count: 2)
         expect(page).to have_css('.wallet-connect--button[data-sign--metamask-target="connectButton"]', count: 1)
+        expect(page).to have_css('.wallet-connect--button .wallet-logo')
+      end
+
+      it 'links to OREID stimulus controller' do
+        expect(page).to have_css('.wallet-connect--button', count: 1, text: 'ORE ID')
+        expect(page).to have_css('.wallet-connect--button[data-action="click->sign--ore-id#switch"]', count: 1)
+        expect(page).to have_css('.wallet-connect--button[data-sign--ore-id-target="otherConnectButtons"]', count: 2)
+        expect(page).to have_css('.wallet-connect--button[data-sign--ore-id-target="connectButton"]', count: 1)
         expect(page).to have_css('.wallet-connect--button .wallet-logo')
       end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -824,6 +824,14 @@ describe Account do
     it { is_expected.to eq(wallet.address) }
   end
 
+  describe '#ore_id_address_for_blockchain' do
+    let!(:wallet) { create(:ore_id_wallet) }
+    let!(:account) { wallet.account }
+    subject { account.ore_id_address_for_blockchain(wallet._blockchain) }
+
+    it { is_expected.to eq(wallet.address) }
+  end
+
   describe '#wallets_for_blockchain' do
     let!(:wallet) { create(:wallet) }
     let!(:wallet2) { create(:eth_wallet, account: wallet.account) }

--- a/spec/models/blockchain/ethereum_spec.rb
+++ b/spec/models/blockchain/ethereum_spec.rb
@@ -17,7 +17,7 @@ describe Blockchain::Ethereum, vcr: true do
   specify { expect(described_class.new.url_for_address_human('null')).to eq('https://etherscan.io/address/null') }
   specify { expect(described_class.new.url_for_address_api('null')).to eq('https://mainnet.infura.io/addr/null') }
   specify { expect(described_class.new.supported_by_wallet_connect?).to be_truthy }
-  specify { expect(described_class.new.supported_by_ore_id?).to be_falsey }
+  specify { expect(described_class.new.supported_by_ore_id?).to be_truthy }
   specify { expect(described_class.new.ore_id_name).to eq 'eth_main' }
   specify { expect(described_class.new.current_block).to be_an(Integer) }
 end

--- a/spec/models/ore_id_service_spec.rb
+++ b/spec/models/ore_id_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
     context 'with algorand blockhain' do
       specify do
         VCR.use_cassette('ore_id_service/algo_wallet_created', match_requests_on: %i[method uri]) do
-          expect { subject.create_wallet(Blockchain::AlgorandTest.new) }.to change(subject.ore_id.wallets, :count).by(2)
+          expect { subject.create_wallet(Blockchain::AlgorandTest.new) }.to change(subject.ore_id.wallets, :count).by(3)
         end
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
     context 'with ethereum blockhain' do
       specify do
         VCR.use_cassette('ore_id_service/eth_wallet_created', match_requests_on: %i[method uri]) do
-          expect { subject.create_wallet(Blockchain::EthereumRopsten.new) }.to change(subject.ore_id.wallets, :count).by(1)
+          expect { subject.create_wallet(Blockchain::EthereumRopsten.new) }.to change(subject.ore_id.wallets, :count).by(3)
         end
       end
     end

--- a/spec/models/ore_id_service_spec.rb
+++ b/spec/models/ore_id_service_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
     end
 
     specify do
-      url = 'https://staging.service.oreid.io/auth?app_access_token=test&background_color=FFFFFF&callback_url=localhost&provider=email&state=dummystate'
+      url = 'https://service.oreid.io/auth?app_access_token=test&background_color=FFFFFF&callback_url=localhost&provider=email&state=dummystate'
       hmac = build(:ore_id_hmac, url)
       expect(subject.authorization_url('localhost', 'dummystate')).to eq("#{url}&hmac=#{hmac}")
     end
@@ -217,7 +217,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
     end
 
     specify do
-      url = 'https://staging.service.oreid.io/recover-account?account=ore1ryuzfqwy&app_access_token=test&background_color=FFFFFF&callback_url=localhost&email=dummyemail&provider=email&recover_action=republic&state=dummystate'
+      url = 'https://service.oreid.io/recover-account?account=ore1ryuzfqwy&app_access_token=test&background_color=FFFFFF&callback_url=localhost&email=dummyemail&provider=email&recover_action=republic&state=dummystate'
       hmac = build(:ore_id_hmac, url)
       expect(subject.reset_url('localhost', 'dummystate', 'dummmyrecovery')).to eq("#{url}&hmac=#{hmac}")
     end
@@ -239,7 +239,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
 
     specify do
       generated_url = subject.sign_url(transaction: transaction, callback_url: 'localhost', state: 'dummystate')
-      expected_url = 'https://staging.service.oreid.io/sign?account=ore1ryuzfqwy&app_access_token=test&broadcast=true&callback_url=localhost&chain_account=YF6FALSXI4BRUFXBFHYVCOKFROAWBQZ42Y4BXUK7SDHTW7B27TEQB3AHSA&chain_network=algo_test&return_signed_transaction=false&state=dummystate&transaction=eyJ0eXBlIjoicGF5IiwiZnJvbSI6IllGNkZBTFNYSTRCUlVGWEJGSFlWQ09L%0ARlJPQVdCUVo0Mlk0QlhVSzdTREhUVzdCMjdURVFCM0FIU0EiLCJ0byI6IkUz%0ASVQyVERXRUpTNTVYQ0k1Tk9CMkhPTjZYVUJJWjZTRFQyVEFIVEtEUU1LUjRB%0ASEVRQ1JPT1hGSUUiLCJhbW91bnQiOjF9%0A'
+      expected_url = 'https://service.oreid.io/sign?account=ore1ryuzfqwy&app_access_token=test&broadcast=true&callback_url=localhost&chain_account=YF6FALSXI4BRUFXBFHYVCOKFROAWBQZ42Y4BXUK7SDHTW7B27TEQB3AHSA&chain_network=algo_test&return_signed_transaction=false&state=dummystate&transaction=eyJ0eXBlIjoicGF5IiwiZnJvbSI6IllGNkZBTFNYSTRCUlVGWEJGSFlWQ09L%0ARlJPQVdCUVo0Mlk0QlhVSzdTREhUVzdCMjdURVFCM0FIU0EiLCJ0byI6IkUz%0ASVQyVERXRUpTNTVYQ0k1Tk9CMkhPTjZYVUJJWjZTRFQyVEFIVEtEUU1LUjRB%0ASEVRQ1JPT1hGSUUiLCJhbW91bnQiOjF9%0A'
       hmac = build(:ore_id_hmac, expected_url)
       expect(generated_url).to eq("#{expected_url}&hmac=#{hmac}")
     end

--- a/spec/requests/api/v1/wallet_configuration_flow_spec.rb
+++ b/spec/requests/api/v1/wallet_configuration_flow_spec.rb
@@ -56,7 +56,7 @@ describe 'Wallet configuration flow', type: :request do
 
     expect(status).to eq(200)
     reset_url_response = JSON.parse(response.body)
-    expect(reset_url_response['resetUrl']).to start_with 'https://staging.service.oreid.io/recover-account?account='
+    expect(reset_url_response['resetUrl']).to start_with 'https://service.oreid.io/recover-account?account='
 
     expect(ore_id_account.reload.state).to eq 'unclaimed'
   end

--- a/spec/vcr/OreIdAccount/1_6.yml
+++ b/spec/vcr/OreIdAccount/1_6.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"hunter-c8a5227efb712dcbf34321d61a4adce807c36f8e","email":"me+9732ac86a39e06e21179f5e32ca35221620f48a6@example.com","picture":null,"user_password":"a5d935fcdb3b2ea20cdeb063378b99316dc8702c933b724b278f40cd05597eab!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 19 Mar 2021 00:38:22 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1rmttj2mb
+    uri: https://service.oreid.io/api/account/user?account=ore1rmttj2mb
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdAccount/1_7.yml
+++ b/spec/vcr/OreIdAccount/1_7.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdAccount/1_8.yml
+++ b/spec/vcr/OreIdAccount/1_8.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdAccount/1_9.yml
+++ b/spec/vcr/OreIdAccount/1_9.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdAccount/_sync_remote_/when_ok/1_15_3_1.yml
+++ b/spec/vcr/OreIdAccount/_sync_remote_/when_ok/1_15_3_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdAccount/_sync_remote_/when_pending_manual/1_15_2_1.yml
+++ b/spec/vcr/OreIdAccount/_sync_remote_/when_pending_manual/1_15_2_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdAccount/when_pending/1_10_1.yml
+++ b/spec/vcr/OreIdAccount/when_pending/1_10_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"hunter-29e3e791666d5b539ab90fde6938df15c26ef55f","email":"me+e03263b2c9ee235e34332db4cc6174fbbc5e7e28@example.com","picture":null,"user_password":"2d3d80dd3c1ce3315b7c3a96574e987f6d4ac162dd40aec6618ecf481fb11a34!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 19 Mar 2021 00:55:23 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1rmtumbzt
+    uri: https://service.oreid.io/api/account/user?account=ore1rmtumbzt
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdService/_create_wallet/with_algorand_blockhain/1_2_1_1.yml
+++ b/spec/vcr/OreIdService/_create_wallet/with_algorand_blockhain/1_2_1_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdService/_create_wallet/with_ethereum_blockhain/1_2_2_1.yml
+++ b/spec/vcr/OreIdService/_create_wallet/with_ethereum_blockhain/1_2_2_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/OreIdService/_reset_url/1_9_1.yml
+++ b/spec/vcr/OreIdService/_reset_url/1_9_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/Sign_OreIdController/behaves_like_ore_id_callbacks/_auth_url/returns_auth_url.yml
+++ b/spec/vcr/Sign_OreIdController/behaves_like_ore_id_callbacks/_auth_url/returns_auth_url.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/app-token
+    uri: https://service.oreid.io/api/app-token
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr/WalletProvision/provisioning_step-by-step/1_10_1.yml
+++ b/spec/vcr/WalletProvision/provisioning_step-by-step/1_10_1.yml
@@ -62,7 +62,7 @@ http_interactions:
   recorded_at: Thu, 14 Jan 2021 11:56:41 GMT
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/transaction/sign
+    uri: https://service.oreid.io/api/transaction/sign
     body:
       encoding: UTF-8
       string: '{"account":"ore1raevigpd","user_password":"b1002674f2b8fc0a794ecbf1ea78bfdb79a9bac1f3effdcea7c1c3929aa5647b!","chain_account":"YFGM3UODOZVHSI4HXKPXOKFI6T2YCIK3HKWJYXYFQBONJD4D3HD2DPMYW4","broadcast":true,"chain_network":"algo_test","return_signed_transaction":true,"transaction":"eyJmcm9tIjoiWUZHTTNVT0RPWlZIU0k0SFhLUFhPS0ZJNlQyWUNJSzNIS1dK\nWVhZRlFCT05KRDREM0hEMkRQTVlXNCIsInRvIjoiWUZHTTNVT0RPWlZIU0k0\nSFhLUFhPS0ZJNlQyWUNJSzNIS1dKWVhZRlFCT05KRDREM0hEMkRQTVlXNCIs\nImFtb3VudCI6MCwidHlwZSI6ImF4ZmVyIiwiYXNzZXRJbmRleCI6MTMwNzYz\nNjd9\n"}'

--- a/spec/vcr/ore_id_service/algo_wallet_created.yml
+++ b/spec/vcr/ore_id_service/algo_wallet_created.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"hunter-d0de39ec8bb6dd846a4a8119571dd25969bc634e","email":"me+453e5dd7012a351ec8573112d747e69d906bb544@example.com","picture":null,"user_password":"01436e44dbda2593753983621afe5c6a04c75c5bf85edcce762cf76ee7105fcc!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Thu, 18 Mar 2021 15:45:39 GMT
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-chain-account
+    uri: https://service.oreid.io/api/custodial/new-chain-account
     body:
       encoding: UTF-8
       string: '{"account_name":"ore1rmsqv5lr","account_type":"native","user_password":"01436e44dbda2593753983621afe5c6a04c75c5bf85edcce762cf76ee7105fcc!","chain_network":"algo_test"}'
@@ -92,7 +92,7 @@ http_interactions:
   recorded_at: Thu, 18 Mar 2021 15:45:51 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy 
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy 
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/ore_id_service/eth_wallet_created.yml
+++ b/spec/vcr/ore_id_service/eth_wallet_created.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"hunter-f902c7fa14a74f1dd1dd2ba75dfbae34759b1995","email":"me+44122360fa0e31f369ae5c0a0a1cd2e6e49bdf48@example.com","picture":null,"user_password":"5cf960ffcb55411b76eec70e53ce2ca4dd257d26838d6ae42f0e2aaa61bd61a6!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Thu, 18 Mar 2021 15:46:05 GMT
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-chain-account
+    uri: https://service.oreid.io/api/custodial/new-chain-account
     body:
       encoding: UTF-8
       string: '{"account_name":"ore1rmsq13f1","account_type":"native","user_password":"5cf960ffcb55411b76eec70e53ce2ca4dd257d26838d6ae42f0e2aaa61bd61a6!","chain_network":"eth_ropsten"}'
@@ -92,7 +92,7 @@ http_interactions:
   recorded_at: Thu, 18 Mar 2021 15:46:15 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy 
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy 
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/ore_id_service/new_tx.yml
+++ b/spec/vcr/ore_id_service/new_tx.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/transaction/sign
+    uri: https://service.oreid.io/api/transaction/sign
     body:
       encoding: UTF-8
       string: '{"account":"ore1ryuzfqwy","user_password":"7b737b93896abe12434b9efc57c43d204d6c51beababb83f7cbfb17ee88a39a5!","chain_account":"YFGM3UODOZVHSI4HXKPXOKFI6T2YCIK3HKWJYXYFQBONJD4D3HD2DPMYW4","broadcast":true,"chain_network":"algo_test","return_signed_transaction":true,"transaction":"eyJmcm9tIjoiWUZHTTNVT0RPWlZIU0k0SFhLUFhPS0ZJNlQyWUNJSzNIS1dK\nWVhZRlFCT05KRDREM0hEMkRQTVlXNCIsInRvIjoiRTNJVDJURFdFSlM1NVhD\nSTVOT0IySE9ONlhVQklaNlNEVDJUQUhUS0RRTUtSNEFIRVFDUk9PWEZJRSIs\nImFtb3VudCI6MSwidHlwZSI6InBheSJ9\n"}'

--- a/spec/vcr/ore_id_service/ore1ryuzfqwy.yml
+++ b/spec/vcr/ore_id_service/ore1ryuzfqwy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"hunter-1436a03f1e078652999eb929a56dc13485dee45c","email":"me+a6396cea1dc3f191e0da5ad89436c47beb689056@example.com","picture":"","user_password":"a63f9e02e6de8520785d376bd0089424d9f301119949c8cce0d91a7db7c5c32a!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Mon, 26 Oct 2020 08:01:51 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/ore_id_service/ore1ryuzfqwy_errors.yml
+++ b/spec/vcr/ore_id_service/ore1ryuzfqwy_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"hunter-1436a03f1e078652999eb929a56dc13485dee45c","email":"me+a6396cea1dc3f191e0da5ad89436c47beb689056@example.com","picture":"","user_password":"a63f9e02e6de8520785d376bd0089424d9f301119949c8cce0d91a7db7c5c32a!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Mon, 26 Oct 2020 08:01:51 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/ore_id_service/ore1ryuzfqwy_password_updated.yml
+++ b/spec/vcr/ore_id_service/ore1ryuzfqwy_password_updated.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"hunter-1436a03f1e078652999eb929a56dc13485dee45c","email":"me+a6396cea1dc3f191e0da5ad89436c47beb689056@example.com","picture":"","user_password":"a63f9e02e6de8520785d376bd0089424d9f301119949c8cce0d91a7db7c5c32a!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Mon, 26 Oct 2020 08:01:51 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/ore_id_service/ore1ryuzfqwy_permissions_missing.yml
+++ b/spec/vcr/ore_id_service/ore1ryuzfqwy_permissions_missing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ryuzfqwy
+    uri: https://service.oreid.io/api/account/user?account=ore1ryuzfqwy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/ore_id_service/token.yml
+++ b/spec/vcr/ore_id_service/token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/app-token
+    uri: https://service.oreid.io/api/app-token
     body:
       encoding: UTF-8
       string: ''

--- a/spec/vcr/ore_id_service/token_for_recovery.yml
+++ b/spec/vcr/ore_id_service/token_for_recovery.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/app-token
+    uri: https://service.oreid.io/api/app-token
     body:
       encoding: UTF-8
       string: '{"secrets":[{"type":"RepublicAccountRecoveryToken","value":"dummmyrecovery"}]}'

--- a/spec/vcr/wallet_configuration_flow/password_reset.yml
+++ b/spec/vcr/wallet_configuration_flow/password_reset.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/app-token
+    uri: https://service.oreid.io/api/app-token
     body:
       encoding: UTF-8
       string: '{"secrets":[{"type":"RepublicAccountRecoveryToken","value":"zOJNjCa9tUiktULlJMsYBluxXwNw7zsBlWVv6PpFbr6iyBiNsqsLOkhp+Pge0XNaUt6JSi7Vr5h7x+cpe4C3CQ=="}]}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Thu, 01 Apr 2021 00:01:00 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ro5f2slw
+    uri: https://service.oreid.io/api/account/user?account=ore1ro5f2slw
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/wallet_configuration_flow/sync_ore_id.yml
+++ b/spec/vcr/wallet_configuration_flow/sync_ore_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://staging.service.oreid.io/api/custodial/new-user
+    uri: https://service.oreid.io/api/custodial/new-user
     body:
       encoding: UTF-8
       string: '{"name":"Eva Smith","user_name":"wallet creation test","email":"create_a_wallet@for_me.com","email_verified":true,"picture":null,"user_password":"71a89055e394c22e0b9aaa05bfed628ea5a6b91ca1be990070abc0127ef23d2d!","phone":"","account_type":"native"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Wed, 31 Mar 2021 11:07:01 GMT
 - request:
     method: get
-    uri: https://staging.service.oreid.io/api/account/user?account=ore1ro5f2slw
+    uri: https://service.oreid.io/api/account/user?account=ore1ro5f2slw
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/178476791
https://www.pivotaltracker.com/story/show/178474238
https://www.pivotaltracker.com/story/show/177615677
https://www.pivotaltracker.com/story/show/178441351

- Enable `Blockchain::Ethereum#supported_by_oreid?`
- Fix `AwardDecorator#recipient_wallet_address`
- Add `Account#ore_id_address_for_blockchain`
- Switch default OREID server back to `service.oreid.io`
- Add `sign/ore_id_controller.js` to handle ORE ID transaction sign
- Update Metamask and WalletConnect controllers to support multiple payment methods
- Update transfers page UI to include ORE ID payment method selection
- Fix transfers page payments