### PR TITLE
Fix broadcast decoration

### DIFF
--- a/app/models/blockchain_transaction_award.rb
+++ b/app/models/blockchain_transaction_award.rb
@@ -50,7 +50,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_issuer_#{blockchain_transactable.id}",
         partial: 'dashboard/transfers/issuer',
-        locals: { transfer: blockchain_transactable.decorate }
+        locals: { transfer: blockchain_transactable }
       )
 
       broadcast_replace_later_to(
@@ -58,7 +58,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_recipient_#{blockchain_transactable.id}",
         partial: 'dashboard/transfers/recipient',
-        locals: { transfer: blockchain_transactable.decorate }
+        locals: { transfer: blockchain_transactable }
       )
 
       broadcast_replace_later_to(

--- a/app/models/blockchain_transaction_award.rb
+++ b/app/models/blockchain_transaction_award.rb
@@ -42,7 +42,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_history_button_#{blockchain_transactable.id}",
         partial: 'dashboard/transfers/transfer_history_button',
-        locals: { transfer: blockchain_transactable.decorate }
+        locals: { transfer: blockchain_transactable }
       )
 
       broadcast_replace_later_to(
@@ -66,7 +66,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_button_public_#{blockchain_transactable.id}",
         partial: 'shared/transfer_button_public',
-        locals: { transfer: blockchain_transactable.decorate }
+        locals: { transfer: blockchain_transactable }
       )
 
       broadcast_replace_later_to(
@@ -74,7 +74,7 @@ class BlockchainTransactionAward < BlockchainTransaction
         :updates,
         target: "transfer_button_admin_#{blockchain_transactable.id}",
         partial: 'shared/transfer_button_admin',
-        locals: { transfer: blockchain_transactable.decorate }
+        locals: { transfer: blockchain_transactable }
       )
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -333,24 +333,20 @@ class Project < ApplicationRecord
     def broadcast_hot_wallet_mode
       broadcast_replace_later_to 'project_hot_wallet_modes',
                                  target: "project_#{id}_hot_wallet_mode",
-                                 partial: 'dashboard/transfers/hot_wallet_mode',
-                                 locals: { project: decorate }
+                                 partial: 'dashboard/transfers/hot_wallet_mode', locals: { project: self }
 
       broadcast_replace_later_to "transfer_project_#{id}_hot_wallet_mode",
                                  target: "transfer_project_#{id}_hot_wallet_mode",
-                                 partial: 'shared/transfer_prioritize_button/mode',
-                                 locals: { project: decorate }
+                                 partial: 'shared/transfer_prioritize_button/mode', locals: { project: self }
     end
 
     def broadcast_batch_size
       broadcast_replace_later_to 'project_transfer_batch_size',
                                  target: "project_#{id}_transfer_batch_size",
-                                 partial: 'dashboard/transfers/batch_size',
-                                 locals: { project: decorate }
+                                 partial: 'dashboard/transfers/batch_size', locals: { project: self }
 
       broadcast_replace_later_to 'project_transfer_batch_size_modal_form',
                                  target: "project_#{id}_transfer_batch_size_modal_form",
-                                 partial: 'projects/batch_size_modal_form',
-                                 locals: { project: decorate }
+                                 partial: 'projects/batch_size_modal_form', locals: { project: self }
     end
 end

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -22,7 +22,7 @@ class Verification < ApplicationRecord
         broadcast_replace_to "mission_#{account.managed_mission&.id}_account_wallets",
                              target: "account_#{account.id}_wallet_#{wallet.id}",
                              partial: 'accounts/partials/index/wallet',
-                             locals: { wallet: wallet.decorate }
+                             locals: { wallet: wallet }
       end
     end
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -114,14 +114,14 @@ class Wallet < ApplicationRecord
       broadcast_append_later_to "mission_#{account.managed_mission&.id}_account_wallets",
                                 target: "account_#{account.id}_wallet_#{id}",
                                 partial: 'accounts/partials/index/wallet',
-                                locals: { wallet: decorate }
+                                locals: { wallet: self }
     end
 
     def broadcast_update
       broadcast_replace_to "mission_#{account.managed_mission&.id}_account_wallets",
                            target: "account_#{account.id}_wallet_#{id}",
                            partial: 'accounts/partials/index/wallet',
-                           locals: { wallet: decorate }
+                           locals: { wallet: self }
     end
 
     def broadcast_destroy

--- a/app/views/dashboard/transfers/_issuer.html.erb
+++ b/app/views/dashboard/transfers/_issuer.html.erb
@@ -1,4 +1,5 @@
 <%= turbo_frame_tag "transfer_issuer_#{transfer.id}", target: "_top" do %>
+  <% transfer = transfer.decorate %>
   <% issuer = transfer.issuer.decorate %>
 
   <div class="account-preview">

--- a/app/views/dashboard/transfers/_recipient.html.erb
+++ b/app/views/dashboard/transfers/_recipient.html.erb
@@ -1,4 +1,5 @@
 <%= turbo_frame_tag "transfer_recipient_#{transfer.id}", target: "_top" do %>
+  <% transfer = transfer.decorate %>
   <% account = transfer.account.decorate %>
 
   <div class="account-preview">

--- a/app/views/shared/_transfer_prioritize_button.html.erb
+++ b/app/views/shared/_transfer_prioritize_button.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "transfer_prioritize_button_#{transfer.id}", target: '_top' do %>
-  <% if transfer.show_prioritize_button? %>
+  <% if transfer.decorate.show_prioritize_button? %>
     <div class="transfers-table__transfer__button__history">
       <%= link_to prioritize_project_dashboard_transfer_path(project_id: transfer.project.id, id: transfer.id),
                   class: 'transfer-algo-btn',


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/178340295

When broadcasting partials, locals are serialised into gids before loaded and initialised by a worker in `Turbo::Streams::ActionBroadcastJob`, so the decoration needs to be re-applied inside the partial.

TODO: Investigate a way to patch ActionBroadcastJob to run decorators automatically
similar to controllers.