### PR TITLE
Customise `Turbo::Streams::ActionBroadcastJob` to auto-decorate locals

### DIFF
--- a/app/jobs/turbo/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo/streams/action_broadcast_job.rb
@@ -1,0 +1,14 @@
+# https://github.com/hotwired/turbo-rails/blob/main/app/jobs/turbo/streams/action_broadcast_job.rb
+
+# The job that powers all the <tt>broadcast_$action_later</tt> broadcasts available in <tt>Turbo::Streams::Broadcasts</tt>.
+class Turbo::Streams::ActionBroadcastJob < ApplicationJob
+  def perform(stream, action:, target:, **rendering)
+    rendering[:locals].transform_values! do |v|
+      v.decorate
+    rescue Draper::UninferrableDecoratorError, NoMethodError
+      v
+    end
+
+    Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target, **rendering
+  end
+end

--- a/app/jobs/turbo/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo/streams/action_broadcast_job.rb
@@ -3,7 +3,7 @@
 # The job that powers all the <tt>broadcast_$action_later</tt> broadcasts available in <tt>Turbo::Streams::Broadcasts</tt>.
 class Turbo::Streams::ActionBroadcastJob < ApplicationJob
   def perform(stream, action:, target:, **rendering)
-    rendering[:locals].transform_values! do |v|
+    rendering[:locals]&.transform_values! do |v|
       v.decorate
     rescue Draper::UninferrableDecoratorError, NoMethodError
       v

--- a/spec/jobs/turbo/streams/action_broadcast_job_spec.rb
+++ b/spec/jobs/turbo/streams/action_broadcast_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Turbo::Streams::ActionBroadcastJob, type: :job do
+  subject { described_class.perform_now('dummy_stream', action: 'dummy_action', target: 'dummy_target', locals: locals) }
+
+  context 'with decoratable locals' do
+    let(:project) { create(:project) }
+    let(:locals) { { project: project } }
+
+    specify do
+      expect(Turbo::StreamsChannel).to receive(:broadcast_action_to)
+      expect(project).to receive(:decorate).and_call_original
+
+      subject
+    end
+  end
+
+  context 'with non-decoratable locals' do
+    let(:project_role) { create(:project_role) }
+    let(:locals) { { project_role: project_role } }
+
+    specify do
+      expect(Turbo::StreamsChannel).to receive(:broadcast_action_to)
+      expect(project_role).to receive(:decorate).and_call_original
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
Update for:
https://www.pivotaltracker.com/story/show/178340295
https://www.pivotaltracker.com/story/show/178418211