### PR TITLE
Improve Awards data integrity for CSV export

### DIFF
--- a/app/decorators/award_decorator.rb
+++ b/app/decorators/award_decorator.rb
@@ -82,7 +82,7 @@ class AwardDecorator < Draper::Decorator
       issuer.last_name,
       latest_blockchain_transaction&.source,
       total_amount,
-      latest_blockchain_transaction&.tx_hash,
+      ethereum_transaction_address,
       token&.blockchain&.name,
       transferred_at,
       created_at

--- a/app/models/award.rb
+++ b/app/models/award.rb
@@ -359,6 +359,10 @@ class Award < ApplicationRecord
     update!(transaction_error: error, status: :accepted)
   end
 
+  def populate_recipient_wallet
+    self.recipient_wallet = account.wallets.find_by(address: recipient_address, _blockchain: token&._blockchain)
+  end
+
   delegate :image, to: :team, prefix: true, allow_nil: true
 
   private
@@ -398,10 +402,6 @@ class Award < ApplicationRecord
       return if recipient_wallet._blockchain == token&._blockchain
 
       errors[:recipient_wallet_id] << 'wallet and token are not in the same network'
-    end
-
-    def populate_recipient_wallet
-      self.recipient_wallet = account.wallets.find_by(address: recipient_address, _blockchain: token&._blockchain)
     end
 
     def abort_destroy

--- a/db/data_migrations/20210629004508_populate_recipient_wallet_for_awards.rb
+++ b/db/data_migrations/20210629004508_populate_recipient_wallet_for_awards.rb
@@ -1,0 +1,8 @@
+class PopulateRecipientWalletForAwards < ActiveRecord::DataMigration
+  def up
+    Award.paid.where(recipient_wallet: nil).find_each do |award|
+      award.populate_recipient_wallet
+      award.save
+    end
+  end
+end

--- a/spec/data_migrations/20210629004508_populate_recipient_wallet_for_awards_spec.rb
+++ b/spec/data_migrations/20210629004508_populate_recipient_wallet_for_awards_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require Rails.root.join('db/data_migrations/20210629004508_populate_recipient_wallet_for_awards')
+
+describe PopulateRecipientWalletForAwards do
+  subject { described_class.new.up }
+
+  context 'when award has recipient wallet' do
+    let!(:award) { FactoryBot.create(:award, :ropsten, :paid, :with_recipient_wallet) }
+
+    specify do
+      expect_any_instance_of(Award).not_to receive(:populate_recipient_wallet)
+      subject
+    end
+  end
+
+  context 'when award doesnt have recipient wallet' do
+    let!(:award) { FactoryBot.create(:award, :ropsten, :paid) }
+    let!(:wallet) { FactoryBot.create(:wallet, :ropsten, account: award.account) }
+
+    specify do
+      expect_any_instance_of(Award).to receive(:populate_recipient_wallet).and_call_original
+      subject
+      award.reload
+
+      expect(award.recipient_wallet).to eq(wallet)
+    end
+  end
+end

--- a/spec/factories/award_types.rb
+++ b/spec/factories/award_types.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     sequence(:name) { |n| "Award Type #{n}" }
     goal { Faker::Lorem.sentence(word_count: 3) }
     description { Faker::Lorem.sentence }
+
+    trait :ropsten do
+      association :project, factory: %i[project ropsten]
+    end
   end
 end

--- a/spec/factories/awards.rb
+++ b/spec/factories/awards.rb
@@ -1,11 +1,23 @@
 FactoryBot.define do
   factory :award do
     account
-    transfer_type
     award_type
     issuer { account }
     sequence(:name) { |n| "Award #{n}" }
     amount { 10 }
     image { dummy_image }
+
+    trait :paid do
+      status { :paid }
+    end
+
+    trait :ropsten do
+      association :award_type, factory: %i[award_type ropsten]
+    end
+
+    trait :with_recipient_wallet do
+      ropsten
+      recipient_wallet { association :wallet, _blockchain: :ethereum_ropsten, address: '0x42D00fC2Efdace4859187DE4865Df9BaA320D5dB', account: account }
+    end
   end
 end

--- a/spec/factories/blockchain_transactions.rb
+++ b/spec/factories/blockchain_transactions.rb
@@ -4,5 +4,12 @@ FactoryBot.define do
     network { :ethereum }
     destination { '0xbbc7e3ee37977ca508f63230471d1001d22bfdd5' }
     tx_hash { '0x5d372aec64aab2fc031b58a872fb6c5e11006c5eb703ef1dd38b4bcac2a9977d' }
+
+    trait :ropsten do
+      network { :ethereum_ropsten }
+      token { association :token, :eth, :ropsten }
+      source { '0xbbc7e3ee37977ca508f63230471d1001d22bfdd5' }
+      current_block { 0 }
+    end
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     long_id { Faker::Internet.uuid }
     title { Faker::Lorem.words(number: 2).join(' ') }
     description { Faker::Lorem.sentence(word_count: 5) }
+
+    trait :ropsten do
+      association :token, factory: %i[token eth ropsten]
+    end
   end
 end

--- a/spec/factories/tokens.rb
+++ b/spec/factories/tokens.rb
@@ -1,11 +1,20 @@
 FactoryBot.define do
   factory :token do
     sequence(:name) { |n| "Token #{n}" }
-    denomination { :BTC }
-    coin_type { :btc }
     blockchain_network { :bitcoin_mainnet }
-    symbol { :BTC }
     _blockchain { :bitcoin }
     decimal_places { 0 }
+    denomination { :BTC }
+    coin_type { :btc }
+    symbol { :BTC }
+
+    trait :eth do
+      symbol { nil }
+      _token_type { :eth }
+    end
+
+    trait :ropsten do
+      _blockchain { :ethereum_ropsten }
+    end
   end
 end

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -3,5 +3,11 @@ FactoryBot.define do
     sequence(:name) { |n| "Wallet #{n}" }
     _blockchain { :bitcoin }
     address { '3P3QsMVK89JBNqZQv5zMAKG8FK3kJM4rjt' }
+    account
+
+    trait :ropsten do
+      _blockchain { :ethereum_ropsten }
+      address { '0x42D00fC2Efdace4859187DE4865Df9BaA320D5dB' }
+    end
   end
 end


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/178563491

- Create data migration to populate recipient wallet for all existing awards
- Fix AwardDecorator#to_csv to correctly include tx hash for legacy awards
- Update Factories