### PR TITLE
Readme changes: imagemagick should be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Prerequisites:
 - Bundler
 - Yarn
 - Chrome and [Chromedriver](https://chromedriver.chromium.org/)
+- ImageMagick
 
 You can check actual versions of yarn, node and other tools in docker-compose.yml file.
 


### PR DESCRIPTION
Locally seeds and "RAILS_ENV=test bundle exec rake docs:generate:ordered" fell because of "imagemagick should be installed" error. To fix it "imagemagick" should be installed locally :)

https://www.pivotaltracker.com/n/projects/2167210/stories/178740021
https://www.pivotaltracker.com/n/projects/2167210/stories/178739911