### PR TITLE
Improve awards data migration

### DIFF
--- a/app/models/award.rb
+++ b/app/models/award.rb
@@ -360,7 +360,7 @@ class Award < ApplicationRecord
   end
 
   def populate_recipient_wallet
-    self.recipient_wallet = account.wallets.find_by(address: recipient_address, _blockchain: token&._blockchain)
+    self.recipient_wallet = account&.wallets&.find_by(address: recipient_address, _blockchain: token&._blockchain)
   end
 
   delegate :image, to: :team, prefix: true, allow_nil: true

--- a/db/data_migrations/20210629004508_populate_recipient_wallet_for_awards.rb
+++ b/db/data_migrations/20210629004508_populate_recipient_wallet_for_awards.rb
@@ -1,6 +1,6 @@
 class PopulateRecipientWalletForAwards < ActiveRecord::DataMigration
   def up
-    Award.paid.where(recipient_wallet: nil).find_each do |award|
+    Award.paid.where(recipient_wallet: nil).where.not(account_id: nil).find_each do |award|
       award.populate_recipient_wallet
       award.save
     end

--- a/spec/data_migrations/20210629004508_populate_recipient_wallet_for_awards_spec.rb
+++ b/spec/data_migrations/20210629004508_populate_recipient_wallet_for_awards_spec.rb
@@ -15,14 +15,35 @@ describe PopulateRecipientWalletForAwards do
 
   context 'when award doesnt have recipient wallet' do
     let!(:award) { FactoryBot.create(:award, :ropsten, :paid) }
-    let!(:wallet) { FactoryBot.create(:wallet, :ropsten, account: award.account) }
 
-    specify do
-      expect_any_instance_of(Award).to receive(:populate_recipient_wallet).and_call_original
-      subject
-      award.reload
+    context 'and doesnt have account' do
+      let!(:award) { FactoryBot.create(:award, :ropsten, :paid, account: nil, issuer: FactoryBot.create(:account)) }
 
-      expect(award.recipient_wallet).to eq(wallet)
+      specify do
+        expect_any_instance_of(Award).not_to receive(:populate_recipient_wallet)
+        subject
+      end
+    end
+
+    context 'and account doesnt have a wallet' do
+      specify do
+        subject
+        award.reload
+
+        expect(award.recipient_wallet).to eq(nil)
+      end
+    end
+
+    context 'and account has a wallet' do
+      let!(:wallet) { FactoryBot.create(:wallet, :ropsten, account: award.account) }
+
+      specify do
+        expect_any_instance_of(Award).to receive(:populate_recipient_wallet).and_call_original
+        subject
+        award.reload
+
+        expect(award.recipient_wallet).to eq(wallet)
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/178781587

- Skip awards which don't have account
- Make sure migration runs properly when accounts doesn't have a
suitable wallet

NOTE: There's ~13000 awards on demo matching the migration condition, so the deploy might take a considerable amount of time. 