### PR TITLE
Use whitelabel mission when sending invites

### DIFF
--- a/app/interactors/send_invite.rb
+++ b/app/interactors/send_invite.rb
@@ -29,7 +29,7 @@ class SendInvite
       )
 
       invite.save!
-      UserMailer.send_invite_to_platform(invite.invitable.reload).deliver_now
+      UserMailer.with(whitelabel_mission: whitelabel_mission).send_invite_to_platform(invite.invitable.reload).deliver_now
     end
 
     def email_valid?

--- a/app/views/user_mailer/send_invite_to_platform.html.erb
+++ b/app/views/user_mailer/send_invite_to_platform.html.erb
@@ -3,5 +3,5 @@
 </p>
 
 <p>
-  To accept the invitation follow this <%= link_to 'link', invite_url(@project_role.invite.token) %>.
+  To accept the invitation follow this <%= link_to 'link', invite_url(@project_role.invite.token, host: @host) %>.
 </p>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe UserMailer, type: :mailer do
         To accept the invitation follow this
       ).squish)
     end
+
+    context 'when sent from whitelabel' do
+      let(:whitelabel_mission) { create(:whitelabel_mission) }
+      let(:mail) { UserMailer.with(whitelabel_mission: whitelabel_mission).send_invite_to_platform(project_role) }
+
+      it 'uses whitelabel domain' do
+        expect(mail.body.encoded).to include(whitelabel_mission.whitelabel_domain)
+      end
+    end
   end
 
   describe '#send_invite_to_project' do


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/178849635

- Update SendInvite interactor to pass whitelabel mission to UserMailer
- Update invite template to use whitelabel domain for invite url