### PR TITLE
Add `RepublicAccountRecoveryEnvironment` param for OREID token

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -29,7 +29,7 @@ jobs:
       KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-      KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+      KNAPSACK_PRO_FIXED_QUEUE_SPLIT: false
       BUNDLER_VERSION: 2.2.3
       RACK_ENV: test
       RAILS_ENV: test

--- a/app.json
+++ b/app.json
@@ -81,6 +81,10 @@
       "required": true,
       "value": "false"
     },
+    "OREID_RECOVERY_ENV": {
+      "description": "Aikon ORE ID API recovery environment (default: test)",
+      "required": false
+    },
     "OREID_BASE_DOMAIN": {
       "description": "Aikon ORE ID API domain (default: service.oreid.io)",
       "required": false

--- a/app/models/ore_id_service.rb
+++ b/app/models/ore_id_service.rb
@@ -142,6 +142,10 @@ class OreIdService
     append_hmac_to_url "https://#{BASE_DOMAIN}/sign?#{params.to_query}"
   end
 
+  def recovery_env
+    ENV.fetch('OREID_RECOVERY_ENV', 'test')
+  end
+
   private
 
     def create_remote_params
@@ -169,10 +173,16 @@ class OreIdService
     def create_token_params(recovery_token = nil)
       if recovery_token
         {
-          secrets: [{
-            type: 'RepublicAccountRecoveryToken',
-            value: recovery_token
-          }]
+          secrets: [
+            {
+              type: 'RepublicAccountRecoveryToken',
+              value: recovery_token
+            },
+            {
+              type: 'RepublicAccountRecoveryEnvironment',
+              value: recovery_env
+            }
+          ]
         }
       end
     end

--- a/spec/models/ore_id_service_spec.rb
+++ b/spec/models/ore_id_service_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
         expect(subject.recovery_env).to eq('test')
 
         VCR.use_cassette('ore_id_service/token_recovery_default', match_requests_on: %i[method uri]) do
-          expect(subject.create_token).to be_an(String)
+          expect(subject.create_token('dummmyrecovery')).to be_an(String)
         end
       end
     end
@@ -218,7 +218,7 @@ RSpec.describe OreIdService, type: :model, vcr: true do
         expect(subject.recovery_env).to eq(custom_env)
 
         VCR.use_cassette('ore_id_service/token_recovery_prod', match_requests_on: %i[method uri]) do
-          expect(subject.create_token).to be_an(String)
+          expect(subject.create_token('dummmyrecovery')).to be_an(String)
         end
       end
     end

--- a/spec/models/ore_id_service_spec.rb
+++ b/spec/models/ore_id_service_spec.rb
@@ -196,6 +196,32 @@ RSpec.describe OreIdService, type: :model, vcr: true do
         end
       end
     end
+
+    context 'with default OREID_RECOVERY_ENV' do
+      specify do
+        expect(subject.recovery_env).to eq('test')
+
+        VCR.use_cassette('ore_id_service/token_recovery_default', match_requests_on: %i[method uri]) do
+          expect(subject.create_token).to be_an(String)
+        end
+      end
+    end
+
+    context 'with a custom OREID_RECOVERY_ENV' do
+      let(:custom_env) { 'production' }
+
+      before do
+        stub_const('ENV', ENV.to_hash.merge('OREID_RECOVERY_ENV' => custom_env))
+      end
+
+      specify do
+        expect(subject.recovery_env).to eq(custom_env)
+
+        VCR.use_cassette('ore_id_service/token_recovery_prod', match_requests_on: %i[method uri]) do
+          expect(subject.create_token).to be_an(String)
+        end
+      end
+    end
   end
 
   describe '#authorization_url' do

--- a/spec/vcr/ore_id_service/token_recovery_default.yml
+++ b/spec/vcr/ore_id_service/token_recovery_default.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://service.oreid.io/api/app-token
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Api-Key:
+      - ENV[ORE_ID_API_KEY]
+      Service-Key:
+      - ENV[ORE_ID_SERVICE_KEY]
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 17 Jul 2021 02:16:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"54-9fgzM3IAaA71Wn3wNhhQjhpZVJo"
+      Via:
+      - 1.1 google
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"processId":"95de24c4072a","appAccessToken":"01d42ea6-76a6-4b4e-a112-b32dd9da209d"}'
+    http_version: null
+  recorded_at: Sat, 17 Jul 2021 02:16:15 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/ore_id_service/token_recovery_default.yml
+++ b/spec/vcr/ore_id_service/token_recovery_default.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://service.oreid.io/api/app-token
     body:
       encoding: UTF-8
-      string: ''
+      string: '{"secrets":[{"type":"RepublicAccountRecoveryToken","value":"dummmyrecovery"},{"type":"RepublicAccountRecoveryEnvironment","value":"test"}]}'
     headers:
       Api-Key:
       - ENV[ORE_ID_API_KEY]
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 17 Jul 2021 02:16:15 GMT
+      - Mon, 19 Jul 2021 00:06:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Vary:
@@ -35,14 +35,14 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Etag:
-      - W/"54-9fgzM3IAaA71Wn3wNhhQjhpZVJo"
+      - W/"54-fUe83cogoqtk+Dtj62kTLLFRXPg"
       Via:
       - 1.1 google
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"processId":"95de24c4072a","appAccessToken":"01d42ea6-76a6-4b4e-a112-b32dd9da209d"}'
+      string: '{"processId":"04dd9e7b9ec2","appAccessToken":"5db40ce6-6d39-4ae4-91c4-6b80b7b3e67a"}'
     http_version: null
-  recorded_at: Sat, 17 Jul 2021 02:16:15 GMT
+  recorded_at: Mon, 19 Jul 2021 00:06:23 GMT
 recorded_with: VCR 5.1.0

--- a/spec/vcr/ore_id_service/token_recovery_prod.yml
+++ b/spec/vcr/ore_id_service/token_recovery_prod.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://service.oreid.io/api/app-token
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Api-Key:
+      - ENV[ORE_ID_API_KEY]
+      Service-Key:
+      - ENV[ORE_ID_SERVICE_KEY]
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 17 Jul 2021 02:21:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"54-ojq81XzS5MzNSUCMbmEzh4k/SqU"
+      Via:
+      - 1.1 google
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"processId":"66ef75a8ed7f","appAccessToken":"e3840e4e-f9f8-4414-8222-4ecddd999cbb"}'
+    http_version: null
+  recorded_at: Sat, 17 Jul 2021 02:21:39 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr/ore_id_service/token_recovery_prod.yml
+++ b/spec/vcr/ore_id_service/token_recovery_prod.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://service.oreid.io/api/app-token
     body:
       encoding: UTF-8
-      string: ''
+      string: '{"secrets":[{"type":"RepublicAccountRecoveryToken","value":"dummmyrecovery"},{"type":"RepublicAccountRecoveryEnvironment","value":"production"}]}'
     headers:
       Api-Key:
       - ENV[ORE_ID_API_KEY]
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 17 Jul 2021 02:21:39 GMT
+      - Mon, 19 Jul 2021 00:06:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Vary:
@@ -35,14 +35,14 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Etag:
-      - W/"54-ojq81XzS5MzNSUCMbmEzh4k/SqU"
+      - W/"54-kHd53FjwEHSGwjjmB0qPzZNLZz4"
       Via:
       - 1.1 google
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"processId":"66ef75a8ed7f","appAccessToken":"e3840e4e-f9f8-4414-8222-4ecddd999cbb"}'
+      string: '{"processId":"3533a7b7d8ac","appAccessToken":"e9641a90-08e0-42fe-ae1d-c18bfb5dbd23"}'
     http_version: null
-  recorded_at: Sat, 17 Jul 2021 02:21:39 GMT
+  recorded_at: Mon, 19 Jul 2021 00:06:23 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
Resolves:
https://www.pivotaltracker.com/story/show/178914891

Add param to indicate OREID env.
Controlled by OREID_RECOVERY_ENV variable, default `test`.