### PR TITLE
DatabaseCleaner: Use truncation strategy as a default

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -3,7 +3,15 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before(:each) do
+  config.before do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each, type: :task) do
     DatabaseCleaner.strategy = :truncation
   end
 
@@ -11,7 +19,7 @@ RSpec.configure do |config|
     DatabaseCleaner.start
   end
 
-  config.after do
+  config.append_after(:each) do
     DatabaseCleaner.clean
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -3,11 +3,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each, js: true) do
+  config.before(:each) do
     DatabaseCleaner.strategy = :truncation
   end
 

--- a/spec/tasks/seeds_spec.rb
+++ b/spec/tasks/seeds_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 
 describe 'rake db:seed', type: :task do
-  # required to correctly clean up DB after seeds loading
-  before { DatabaseCleaner.strategy = :truncation }
-
   it 'works' do
     expect { task.invoke }.to_not raise_error
     expect(Account.count).to be_positive


### PR DESCRIPTION
task: https://www.pivotaltracker.com/story/show/178978314

I read docs and suggestions about strategies. It recommends to use `:transaction` everywhere it possible.
Also `transaction` strategy brings random deadlock errors, which can be a real problem with CI.

So, I setup `truncation` strategy for `tasks` specs and left `transaction` as a default strategy.